### PR TITLE
Add simple CircleCI support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ defaults: &defaults
 executors:
   unit-test:
     <<: *defaults
-    resource_class: large
+    resource_class: xlarge
 
 commands:
   dependencies:


### PR DESCRIPTION
Checks it builds and runs the quick and non-CUDA dependent test `./katago runtests`.

Omits the test `./katago runnontinyboardtest` which requires a GPU executor that we don't currently have access to.

Long-term we'd ideally also like to run some of the shell scripts with tests. But they're (a) long-running (`runsearchtestsfp16.sh` took almost an hour on my workstation), (b) just produce output that has to be manually diffed.