### PR TITLE
match: Print timestamp when game finishes

### DIFF
--- a/cpp/command/match.cpp
+++ b/cpp/command/match.cpp
@@ -229,15 +229,15 @@ int MainCmds::match(const vector<string>& args) {
           search->setCopyOfExternalPatternBonusTable(patternBonusTables[spec.botIdx]);
         };
 
-        logger.write(
-          "Launching game between " +
-          botSpecB.botName + "-" + botSpecB.baseParams.getSearchAlgoAsStr() + " (B) " +
-          botSpecW.botName + "-" + botSpecW.baseParams.getSearchAlgoAsStr() + " (W)..."
-        );
+        const string gameDescription = "game " + seed + " between "
+          + botSpecB.botName + "-" + botSpecB.baseParams.getSearchAlgoAsStr() + " (B) "
+          + botSpecW.botName + "-" + botSpecW.baseParams.getSearchAlgoAsStr() + " (W)";
+        logger.write("Launching " + gameDescription);
         gameData = gameRunner->runGame(
           seed, botSpecB, botSpecW, NULL, NULL, logger,
           shouldStopFunc, nullptr, afterInitialization, nullptr
         );
+        logger.write("Finished " + gameDescription);
       }
 
       bool shouldContinue = gameData != NULL;


### PR DESCRIPTION
Changes:
* Print timestamp whenever a game finishes during a `match` run, for easier benchmarking