### PR TITLE
searchresults: Add missing pass suppression case

### DIFF
--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -212,6 +212,12 @@ bool Search::getPlaySelectionValues(
     while(true) {
       for(int movePos = 0; movePos<policySize; movePos++) {
         Loc moveLoc = NNPos::posToLoc(movePos,rootBoard.x_size,rootBoard.y_size,nnXLen,nnYLen);
+        if(suppressPass && moveLoc == Board::PASS_LOC) {
+          locs.push_back(moveLoc);
+          playSelectionValues.push_back(0.);
+          numChildren++;
+          continue;
+        }
         const float* policyProbs = nnOutput->getPolicyProbsMaybeNoised();
         double policyProb = policyProbs[movePos];
         if(!rootHistory.isLegal(rootBoard,moveLoc,rootPla) || policyProb < 0 || (obeyAllowedRootMove && !isAllowedRootMove(moveLoc)))


### PR DESCRIPTION
Issue: When playing against a pass-hardened 1-visit victim, games were still ending from the victim passing too early.

Changes: Apply pass hardening in one additional case in `Search::getPlaySelectionValues()`