### PR TITLE
search: Implement pass sharpening (option to force pass if it makes player win)

### DIFF
--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -369,6 +369,8 @@ vector<SearchParams> Setup::loadParams(
 
     if(cfg.contains("passingBehavior"+idxStr)) params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"+idxStr));
     else if (cfg.contains("passingBehavior"))  params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"));
+    if(cfg.contains("forceWinningPass"+idxStr)) params.forceWinningPass = cfg.getBool("forceWinningPass"+idxStr);
+    else if (cfg.contains("forceWinningPass"))  params.forceWinningPass = cfg.getBool("forceWinningPass");
 
     if(cfg.contains("searchAlgorithm"+idxStr)) params.searchAlgo = SearchParams::strToSearchAlgo(cfg.getString("searchAlgorithm"+idxStr));
     else if (cfg.contains("searchAlgorithm"))  params.searchAlgo = SearchParams::strToSearchAlgo(cfg.getString("searchAlgorithm"));

--- a/cpp/search/searchparams.cpp
+++ b/cpp/search/searchparams.cpp
@@ -4,7 +4,6 @@
 static const std::map<SearchParams::PassingBehavior, const std::string> behavior_to_string = {
     {SearchParams::PassingBehavior::Standard, "standard"},
     {SearchParams::PassingBehavior::AvoidPassAliveTerritory, "avoid-pass-alive-territory"},
-    {SearchParams::PassingBehavior::ForceWinningPass, "force-winning-pass"},
     {SearchParams::PassingBehavior::LastResort, "last-resort"},
     {SearchParams::PassingBehavior::NoSuicide, "no-suicide"},
     {SearchParams::PassingBehavior::OnlyWhenAhead, "only-when-ahead"},
@@ -48,6 +47,7 @@ std::string SearchParams::getSearchAlgoAsStr() const {
 //have changed to preserve the behavior of tests.
 SearchParams::SearchParams()
   :passingBehavior(PassingBehavior::Standard),
+   forceWinningPass(false),
    searchAlgo(SearchAlgorithm::MCTS),
    canPassFirst(true),
    winLossUtilityFactor(1.0),

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -5,13 +5,12 @@
 #include "../game/board.h"
 
 struct SearchParams {
+  // Modifications of pass suppression behavior.
   enum class PassingBehavior {
     // Essentially use vanilla MCTS to determine when passing makes sense
     Standard,
     // Pass when the only legal alternatives are to play in your own pass-alive territory
     AvoidPassAliveTerritory,
-    // Forces a pass if it will make you win
-    ForceWinningPass,
     // Pass when the only legal alternatives are in territory your opponent "almost certainly" (95% chance) owns,
     // or that are "much worse" than passing
     LastResort,
@@ -26,6 +25,8 @@ struct SearchParams {
   static PassingBehavior strToPassingBehavior(const std::string& behaviorStr);
   static std::string passingBehaviorToStr(PassingBehavior behavior);
   PassingBehavior passingBehavior;
+  // If enabled, then we will definitely pass if it wins us the game.
+  bool forceWinningPass;
 
   // Algorithm to use for search
   enum class SearchAlgorithm { MCTS, EMCTS1 };

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -466,7 +466,7 @@ const SearchNode* Search::getChildForMove(const SearchNode* node, Loc moveLoc) c
 Loc Search::getChosenMoveLoc() {
   if(rootNode == NULL)
     return Board::NULL_LOC;
-  if (searchParams.passingBehavior == SearchParams::PassingBehavior::ForceWinningPass
+  if (searchParams.forceWinningPass
       && rootHistory.isLegal(rootBoard, Board::PASS_LOC, rootPla)
       && rootHistory.passWouldEndGame(rootBoard, rootPla)) {
     Board boardCopy(rootBoard);
@@ -505,8 +505,7 @@ bool Search::shouldSuppressPass(const SearchNode* n) const {
     return false;
 
   // When using standard passing, we should only suppressPass in territory scoring. Otherwise, short circuit.
-  if(searchParams.passingBehavior == SearchParams::PassingBehavior::Standard
-      || searchParams.passingBehavior == SearchParams::PassingBehavior::ForceWinningPass) {
+  if(searchParams.passingBehavior == SearchParams::PassingBehavior::Standard) {
     if(!searchParams.fillDameBeforePass)
       return false;
     if(rootHistory.rules.scoringRule != Rules::SCORING_TERRITORY || rootHistory.encorePhase > 0)
@@ -538,8 +537,7 @@ bool Search::shouldSuppressPass(const SearchNode* n) const {
       break;
     }
   }
-  if(passNode == NULL && (searchParams.passingBehavior == SearchParams::PassingBehavior::Standard
-        || searchParams.passingBehavior == SearchParams::PassingBehavior::ForceWinningPass))
+  if(passNode == NULL && searchParams.passingBehavior == SearchParams::PassingBehavior::Standard)
     return false;
 
   double passWeight;
@@ -589,7 +587,6 @@ bool Search::shouldSuppressPass(const SearchNode* n) const {
     }
     // Suppress pass if we find a move that is not a spot that the opponent almost certainly owns
     // or that is adjacent to a pla owned spot, and is not greatly worse than pass.
-    case SearchParams::PassingBehavior::ForceWinningPass:
     case SearchParams::PassingBehavior::LastResort:
     case SearchParams::PassingBehavior::Standard: {
       const double extreme = 0.95;


### PR DESCRIPTION
Changes: 
* Add a new `SearchParams::PassingBehavior` for forcing player to make a pass if it makes the player win

Testing:
* Added a print statement to the pass-forcing code path
* Manually played against a `/dev/null` bot via GTP and checked that the print statement is hit when I pass and make the bot `genmove`. Bot plays `pass` if it is winning
* Launched a `match` run and checked that the print statement is hit