### PR TITLE
.gitignore: Ignore vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,8 @@ out.txt
 .vscode
 
 # For vim
-*.swp
-*.swo
+.*.swp
+.*.swo
 
 # For cmake
 CMakeCache.txt


### PR DESCRIPTION
I usually use vim to edit files, and it's annoying for vim's swap files to get included in `git status`.
This PR adds vim swap files to `.gitignore`.