### PR TITLE
Evaluate_loop.sh now uses config set by curriculum

### DIFF
--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -53,6 +53,7 @@ do
                 echo "Evaluating model $MODEL_DIR against victim $VICTIM_NAME"
                 /engines/KataGo-custom/cpp/katago match \
                     -config /go_attack/configs/match-1gpu.cfg \
+                    -config $VICTIMS_DIR/victim.cfg \
                     -override-config numGamesTotal=100 \
                     -override-config nnModelFile0="$VICTIMS_DIR"/"$VICTIM" \
                     -override-config nnModelFile1="$MODELS_DIR"/"$MODEL_DIR"/model.bin.gz \


### PR DESCRIPTION
Currently, `evaluate_loop.sh` does not update the config it uses to run `match` when the curriculum advances, so every `match` game is run with `maxVisits=1` for the victim. This PR fixes the issue by adding a single line of code to `evaluate_loop.sh`.