### PR TITLE
Curriculum.py now creates selfplay dir if needed

### DIFF
--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -719,6 +719,7 @@ def parse_args() -> argparse.Namespace:
 
 def setup_logging(selfplay_dir: str, log_level: int) -> None:
     """Setup logging to file {selfplay_dir}/curriculum-<timestamp>.log and stdout."""
+    pathlib.Path(selfplay_dir).mkdir(parents=True, exist_ok=True)
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
 


### PR DESCRIPTION
Self-explanatory; occasionally the victimplay Compose file would crash because of this when curriculum.py tried to open the selfplay dir before another service had had the chance to create it