### PR TITLE
curriculum: Don't print error if RE[] tag is missing

### DIFF
--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -235,19 +235,18 @@ def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
     victim_name, victim_color, adv_color = get_victim_adv_colors(game)
     victim_visits = get_max_visits(game, victim_color)
     adv_visits = get_max_visits(game, adv_color)
-    win_color_string = game.get_winner()
-    win_color = Color.from_string(win_color_string) if win_color_string else None
 
     komi = game.get_komi()
     adv_komi = komi if adv_color == Color.WHITE else -komi
 
-    if win_color is None:
+    if win_score is None:
         # either the game tied (which should never happen under default rules)
         # or the game hit the move limit
         adv_minus_victim_score = 0
         adv_minus_victim_score_wo_komi = 0
         winner = None
     else:
+        win_color = Color.from_string(game.get_winner())
         winner = win_color == adv_color
         adv_minus_victim_score = win_score if winner else -win_score
         adv_minus_victim_score_wo_komi = adv_minus_victim_score - adv_komi

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -230,7 +230,6 @@ def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
     game_hash = get_game_hash(game)
     if game_hash is None:
         return None
-    win_score = get_game_score(game)
 
     victim_name, victim_color, adv_color = get_victim_adv_colors(game)
     victim_visits = get_max_visits(game, victim_color)
@@ -239,6 +238,7 @@ def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
     komi = game.get_komi()
     adv_komi = komi if adv_color == Color.WHITE else -komi
 
+    win_score = get_game_score(game)
     if win_score is None:
         # either the game tied (which should never happen under default rules)
         # or the game hit the move limit


### PR DESCRIPTION
## Description

* When pass hardening on, we more frequently see games that hit the move limit of 1600 moves
* Games that hit the move limit don't have a RE[] tag
* We shouldn't log an error when we don't see an RE[] tag or else we may see a bunch of logged errors on every iteration of `curriculum.py`

## Testing

Ran `curriculum.py` on a batch of existing SGFs and no `RE[]` errors appeared