### PR TITLE
Add useLcbForSelfplayMove config option

### DIFF
--- a/cpp/configs/training/victimplay1.cfg
+++ b/cpp/configs/training/victimplay1.cfg
@@ -48,3 +48,8 @@ cudaUseNHWC = auto
 # Internal params------------------------------------------------------------------------------
 
 dynamicScoreUtilityFactor = 0.40
+
+# Uncomment this to force the victim (but not the adversary) to use a lower confidence bound
+# formula to select its moves. This generally makes the network more robust while reducing
+# exploration and randomness.
+# useLcbForSelfplayMove0 = true

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -1193,7 +1193,7 @@ static Loc runBotWithLimits(
 
   //HACK - Disable LCB for making the move (it will still affect the policy target gen)
   bool lcb = toMoveBot->searchParams.useLcbForSelection;
-  if(playSettings.forSelfPlay) {
+  if(playSettings.forSelfPlay && !toMoveBot->searchParams.useLcbForSelfplayMove) {
     toMoveBot->searchParams.useLcbForSelection = false;
   }
 

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -556,6 +556,11 @@ vector<SearchParams> Setup::loadParams(
     if(cfg.contains("useLcbForSelection"+idxStr)) params.useLcbForSelection = cfg.getBool("useLcbForSelection"+idxStr);
     else if(cfg.contains("useLcbForSelection"))   params.useLcbForSelection = cfg.getBool("useLcbForSelection");
     else                                          params.useLcbForSelection = true;
+
+    if(cfg.contains("useLcbForSelfplayMove"+idxStr)) params.useLcbForSelfplayMove = cfg.getBool("useLcbForSelfplayMove"+idxStr);
+    else if(cfg.contains("useLcbForSelfplayMove"))   params.useLcbForSelfplayMove = cfg.getBool("useLcbForSelfplayMove");
+    else                                             params.useLcbForSelfplayMove = false;
+
     if(cfg.contains("lcbStdevs"+idxStr)) params.lcbStdevs = cfg.getDouble("lcbStdevs"+idxStr, 1.0, 12.0);
     else if(cfg.contains("lcbStdevs"))   params.lcbStdevs = cfg.getDouble("lcbStdevs",        1.0, 12.0);
     else                                 params.lcbStdevs = 5.0;

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -100,6 +100,7 @@ struct SearchParams {
   double chosenMovePrune; //Outright prune moves that have fewer than this many visits
 
   bool useLcbForSelection; //Using LCB for move selection?
+  bool useLcbForSelfplayMove; //Use LCB to make moves during self-play?
   double lcbStdevs; //How many stdevs a move needs to be better than another for LCB selection
   double minVisitPropForLCB; //Only use LCB override when a move has this proportion of visits as the top move
   bool useNonBuggyLcb; //LCB was very minorly buggy as of pre-v1.8. Set to true to fix.


### PR DESCRIPTION
This PR adds the `useLcbForSelfplayMove` config option. It's `false` by default, but when set to `true`, it forces the use of the lower confidence bound formula to select moves for the specified player(s) in victimplay.