### PR TITLE
Support predictor networks in evaluate_loop.sh

### DIFF
--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eu
-if [[ $# -lt 1 || $# -gt 3 ]]
+if [[ $# -lt 1 || $# -gt 2 ]]
 then
     echo "Usage: $0 BASE_DIR [PREDICTOR_DIR]"
     echo "Currently expects to be run from within the 'cpp' directory of the KataGo repo."

--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -1,14 +1,15 @@
 #!/bin/bash -eu
-if [[ $# -lt 1 || $# -gt 2 ]]
+if [[ $# -lt 1 || $# -gt 3 ]]
 then
-    echo "Usage: $0 BASE_DIR [SLEEP_INTERVAL]"
+    echo "Usage: $0 BASE_DIR [PREDICTOR_DIR]"
     echo "Currently expects to be run from within the 'cpp' directory of the KataGo repo."
     echo "BASE_DIR is the root of the training run, containing selfplay data, models and related directories."
-    echo "SLEEP_INTERVAL is the number of seconds to sleep between each check for new models, default 30."
+    echo "PREDICTOR_DIR is the path containing predictor models, if applicable."
     exit 0
 fi
 
 BASE_DIR="$1"
+PREDICTOR_DIR="$2"
 MODELS_DIR="$BASE_DIR"/models
 VICTIMS_DIR="$BASE_DIR"/victims
 OUTPUT_DIR="$BASE_DIR"/eval
@@ -16,7 +17,7 @@ mkdir -p "$OUTPUT_DIR"/logs
 mkdir -p "$OUTPUT_DIR"/sgfs
 
 LAST_STEP=0
-SLEEP_INTERVAL=${2:-30}
+SLEEP_INTERVAL=30
 while true
 do
     if [[ ! -d "$MODELS_DIR" || ! -d "$VICTIMS_DIR" ]]
@@ -48,13 +49,20 @@ do
             if [ "$STEP" -gt "$LAST_STEP" ]; then
                 # https://stackoverflow.com/questions/12152626/how-can-i-remove-the-extension-of-a-filename-in-a-shell-script
                 VICTIM_NAME=$(echo "$VICTIM" | cut -f 1 -d '.')
+                EXTRA_CONFIG="numGamesTotal=100"
+
+                if [ -n "$PREDICTOR_DIR" ]; then
+                    # https://stackoverflow.com/questions/4561895/how-to-recursively-find-the-latest-modified-file-in-a-directory
+                    PREDICTOR=$(find $PREDICTOR_DIR -name *.bin.gz -type f -printf '%T@ %p\n' | sort -n | tail -1 | cut -f2- -d" ")
+                    EXTRA_CONFIG+=",predictorPath=$PREDICTOR"
+                fi
 
                 # Run the evaluation
                 echo "Evaluating model $MODEL_DIR against victim $VICTIM_NAME"
                 /engines/KataGo-custom/cpp/katago match \
                     -config /go_attack/configs/match-1gpu.cfg \
-                    -config $VICTIMS_DIR/victim.cfg \
-                    -override-config numGamesTotal=100 \
+                    -config "$VICTIMS_DIR"/victim.cfg \
+                    -override-config "$EXTRA_CONFIG" \
                     -override-config nnModelFile0="$VICTIMS_DIR"/"$VICTIM" \
                     -override-config nnModelFile1="$MODELS_DIR"/"$MODEL_DIR"/model.bin.gz \
                     -sgf-output-dir "$OUTPUT_DIR"/sgfs/"$VICTIM_NAME"_"$MODEL_DIR" \


### PR DESCRIPTION
Mostly self-explanatory. I did remove the `SLEEP_INTERVAL` command line option on `evaluate_loop.sh` because it wasn't being used in other code and would have made the argument parsing more annoying/complicated to continue supporting it alongside the new `PREDICTOR_DIR` argument.