### PR TITLE
"Logit lens" for analysis, match, and victimplay

### DIFF
--- a/cpp/command/analysis.cpp
+++ b/cpp/command/analysis.cpp
@@ -904,6 +904,19 @@ int MainCmds::analysis(const vector<string>& args) {
           continue;
         rbase.reportDuringSearch = true;
       }
+      if(input.find("queryMoves") != input.end()) {
+        std::vector<Loc> queryMoves;
+        bool suc = parseBoardLocs(input, "queryMoves", queryMoves, true);
+        if(!suc)
+          continue;
+        
+        // TODO: Maybe support this in the future? Either that, or change queryMoves to be a single move and not an array
+        if(queryMoves.size() > 1) {
+          reportErrorForId(rbase.id, "queryMoves", "Only one query move at a time is supported currently");
+          continue;
+        }
+        rbase.params.queryMoveLoc = queryMoves.size() > 0 ? queryMoves[0] : Board::NULL_LOC;
+      }
       if(input.find("priority") != input.end()) {
         if(input.find("priorities") != input.end()) {
           reportErrorForId(rbase.id, "priority", "Cannot specify both priority and priorities");

--- a/cpp/dataio/sgf.cpp
+++ b/cpp/dataio/sgf.cpp
@@ -1672,7 +1672,7 @@ void WriteSgf::writeSgf(
         comment += weightBuf;
       }
       if(turnAfterStart < gameData->playoutHistoriesByTurn.size()) {
-        std::vector<SearchPlayoutRecord> history = gameData->playoutHistoriesByTurn[turnAfterStart];
+        const std::vector<SearchPlayoutRecord> &history = gameData->playoutHistoriesByTurn[turnAfterStart];
         if(comment.length() > 0)
           comment += " ";
         comment += "prob_" + Location::toString(gameData->queryMoveLoc, board) + "_hist" + "=";

--- a/cpp/dataio/sgf.cpp
+++ b/cpp/dataio/sgf.cpp
@@ -1671,8 +1671,8 @@ void WriteSgf::writeSgf(
         comment += "weight=";
         comment += weightBuf;
       }
-      if(turnAfterStart < gameData->selectionProbHistoryByTurn.size()) {
-        auto history = gameData->selectionProbHistoryByTurn[turnAfterStart];
+      if(turnAfterStart < gameData->playoutHistoriesByTurn.size()) {
+        std::vector<SearchPlayoutRecord> history = gameData->playoutHistoriesByTurn[turnAfterStart];
         if(comment.length() > 0)
           comment += " ";
         comment += "prob_" + Location::toString(gameData->queryMoveLoc, board) + "_hist" + "=";

--- a/cpp/dataio/sgf.cpp
+++ b/cpp/dataio/sgf.cpp
@@ -68,6 +68,18 @@ static int parseSgfCoord(char c) {
   return -1;
 }
 
+// Port of Python str.join() method basically
+template<typename T>
+static string join(const vector<T>& vec, const string& sep) {
+  ostringstream out;
+  for(int i = 0; i<vec.size(); i++) {
+    if(i > 0)
+      out << sep;
+    out << vec[i];
+  }
+  return out.str();
+}
+
 //MoveNoBSize uses only single bytes
 //If both coords are COORD_MAX, that indicates pass
 static const int COORD_MAX = 128;
@@ -1658,6 +1670,13 @@ void WriteSgf::writeSgf(
           comment += " ";
         comment += "weight=";
         comment += weightBuf;
+      }
+      if(turnAfterStart < gameData->selectionProbHistoryByTurn.size()) {
+        auto history = gameData->selectionProbHistoryByTurn[turnAfterStart];
+        if(comment.length() > 0)
+          comment += " ";
+        comment += "prob_" + Location::toString(gameData->queryMoveLoc, board) + "_hist" + "=";
+        comment += "(" + join(history, ", ") + ")";
       }
     }
 

--- a/cpp/dataio/trainingwrite.cpp
+++ b/cpp/dataio/trainingwrite.cpp
@@ -82,6 +82,10 @@ FinishedGameData::FinishedGameData()
    policyTargetsByTurn(),
    whiteValueTargetsByTurn(),
    nnRawStatsByTurn(),
+
+   queryMoveLoc(Board::NULL_LOC),
+   selectionProbHistoryByTurn(),
+
    finalFullArea(NULL),
    finalOwnership(NULL),
    finalSekiAreas(NULL),

--- a/cpp/dataio/trainingwrite.cpp
+++ b/cpp/dataio/trainingwrite.cpp
@@ -84,7 +84,7 @@ FinishedGameData::FinishedGameData()
    nnRawStatsByTurn(),
 
    queryMoveLoc(Board::NULL_LOC),
-   selectionProbHistoryByTurn(),
+   playoutHistoriesByTurn(),
 
    finalFullArea(NULL),
    finalOwnership(NULL),

--- a/cpp/dataio/trainingwrite.h
+++ b/cpp/dataio/trainingwrite.h
@@ -89,6 +89,9 @@ struct FinishedGameData {
   std::vector<PolicyTarget> policyTargetsByTurn;
   std::vector<ValueTargets> whiteValueTargetsByTurn; //Except this one, we may have some of
   std::vector<NNRawStats> nnRawStatsByTurn;
+
+  Loc queryMoveLoc;
+  std::vector<std::vector<double>> selectionProbHistoryByTurn;
   Color* finalFullArea;
   Color* finalOwnership;
   bool* finalSekiAreas;

--- a/cpp/dataio/trainingwrite.h
+++ b/cpp/dataio/trainingwrite.h
@@ -4,6 +4,7 @@
 #include "../dataio/numpywrite.h"
 #include "../neuralnet/nninputs.h"
 #include "../neuralnet/nninterface.h"
+#include "../search/search.h"
 
 STRUCT_NAMED_PAIR(Loc,loc,int16_t,policyTarget,PolicyTargetMove);
 STRUCT_NAMED_PAIR(std::vector<PolicyTargetMove>*,policyTargets,int64_t,unreducedNumVisits,PolicyTarget);
@@ -91,7 +92,7 @@ struct FinishedGameData {
   std::vector<NNRawStats> nnRawStatsByTurn;
 
   Loc queryMoveLoc;
-  std::vector<std::vector<double>> selectionProbHistoryByTurn;
+  std::vector<std::vector<SearchPlayoutRecord>> playoutHistoriesByTurn;
   Color* finalFullArea;
   Color* finalOwnership;
   bool* finalSekiAreas;

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -1538,6 +1538,11 @@ FinishedGameData* Play::runGame(
     extractValueTargets(whiteValueTargets, toMoveBot, toMoveBot->rootNode);
     gameData->whiteValueTargetsByTurn.push_back(whiteValueTargets);
 
+    if(toMoveBot->searchParams.queryMoveLoc != Board::NULL_LOC) {
+      gameData->queryMoveLoc = toMoveBot->searchParams.queryMoveLoc;
+      gameData->selectionProbHistoryByTurn.push_back(toMoveBot->selectionProbHistory);
+    }
+
     if(!recordFullData) {
       //Go ahead and record this anyways with just the visits, as a bit of a hack so that the sgf output can also write the number of visits.
       int64_t unreducedNumVisits = toMoveBot->getRootVisits();

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -1540,7 +1540,7 @@ FinishedGameData* Play::runGame(
 
     if(toMoveBot->searchParams.queryMoveLoc != Board::NULL_LOC) {
       gameData->queryMoveLoc = toMoveBot->searchParams.queryMoveLoc;
-      gameData->selectionProbHistoryByTurn.push_back(toMoveBot->selectionProbHistory);
+      gameData->playoutHistoriesByTurn.push_back(toMoveBot->playoutHistory);
     }
 
     if(!recordFullData) {

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -367,6 +367,10 @@ vector<SearchParams> Setup::loadParams(
 
     string idxStr = Global::intToString(i);
 
+    if(cfg.contains("trackPassProb"+idxStr)) params.queryMoveLoc = cfg.getBool("trackPassProb"+idxStr) ? Board::PASS_LOC : Board::NULL_LOC;
+    else if (cfg.contains("trackPassProb"))  params.queryMoveLoc = cfg.getBool("trackPassProb") ? Board::PASS_LOC : Board::NULL_LOC;
+    else params.queryMoveLoc = Board::NULL_LOC;
+
     if(cfg.contains("passingBehavior"+idxStr)) params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"+idxStr));
     else if (cfg.contains("passingBehavior"))  params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"));
     if(cfg.contains("forceWinningPass"+idxStr)) params.forceWinningPass = cfg.getBool("forceWinningPass"+idxStr);

--- a/cpp/search/analysisdata.cpp
+++ b/cpp/search/analysisdata.cpp
@@ -4,6 +4,7 @@ AnalysisData::AnalysisData()
   :move(Board::NULL_LOC),
    numVisits(0),
    playSelectionValue(0.0),
+   selectionProb(0.0),
    lcb(0.0),
    radius(0.0),
    utility(0.0),
@@ -28,6 +29,7 @@ AnalysisData::AnalysisData(const AnalysisData& other)
   :move(other.move),
    numVisits(other.numVisits),
    playSelectionValue(other.playSelectionValue),
+   selectionProb(other.selectionProb),
    lcb(other.lcb),
    radius(other.radius),
    utility(other.utility),
@@ -52,6 +54,7 @@ AnalysisData::AnalysisData(AnalysisData&& other) noexcept
   :move(other.move),
    numVisits(other.numVisits),
    playSelectionValue(other.playSelectionValue),
+   selectionProb(other.selectionProb),
    lcb(other.lcb),
    radius(other.radius),
    utility(other.utility),
@@ -81,6 +84,7 @@ AnalysisData& AnalysisData::operator=(const AnalysisData& other) {
   move = other.move;
   numVisits = other.numVisits;
   playSelectionValue = other.playSelectionValue;
+  selectionProb = other.selectionProb;
   lcb = other.lcb;
   radius = other.radius;
   utility = other.utility;
@@ -108,6 +112,7 @@ AnalysisData& AnalysisData::operator=(AnalysisData&& other) noexcept {
   move = other.move;
   numVisits = other.numVisits;
   playSelectionValue = other.playSelectionValue;
+  selectionProb = other.selectionProb;
   lcb = other.lcb;
   radius = other.radius;
   utility = other.utility;

--- a/cpp/search/analysisdata.h
+++ b/cpp/search/analysisdata.h
@@ -11,6 +11,7 @@ struct AnalysisData {
   Loc move;
   int64_t numVisits;
   double playSelectionValue; //Similar units to visits, but might have LCB adjustments
+  double selectionProb; // Temperature-adjusted probability of selecting this move
   double lcb; //In units of utility
   double radius; //In units of utility
   double utility; //From -1 to 1 or -1.25 to -1.25 or other similar bounds, depending on score utility

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -317,6 +317,7 @@ struct Search {
 
   //Mutable---------------------------------------------------------------
   SearchNode* rootNode;
+  std::vector<double> selectionProbHistory; // History of selection probs for the query move during the search
 
   //Services--------------------------------------------------------------
   MutexPool* mutexPool;

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -130,6 +130,21 @@ public:
   bool storeIfNull(SearchNode* node);
 };
 
+// Records info about a playout; used when queryMoveLoc != Board::NULL_LOC
+struct SearchPlayoutRecord {
+  long playoutIdx;
+  double queryMoveSelectionProb;
+  std::vector<Loc> visitedMoves;
+
+  // Sort of silly but we need to pass these to Location::toString inside
+  // of operator<< below
+  int boardXSize;
+  int boardYSize;
+
+  friend std::ostream& operator<<(std::ostream& out, const SearchPlayoutRecord& record);
+  nlohmann::json toJson() const;
+};
+
 struct SearchNode {
   //Locks------------------------------------------------------------------------------
   mutable std::atomic_flag statsLock = ATOMIC_FLAG_INIT;
@@ -317,7 +332,7 @@ struct Search {
 
   //Mutable---------------------------------------------------------------
   SearchNode* rootNode;
-  std::vector<double> selectionProbHistory; // History of selection probs for the query move during the search
+  std::vector<SearchPlayoutRecord> playoutHistory;
 
   //Services--------------------------------------------------------------
   MutexPool* mutexPool;

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -485,6 +485,7 @@ struct Search {
 
   //Useful utility function exposed for outside use
   static uint32_t chooseIndexWithTemperature(Rand& rand, const double* relativeProbs, int numRelativeProbs, double temperature);
+  static void temperatureScaleProbs(const double* relativeProbs, int numRelativeProbs, double temperature, double* buf, bool normalize = true);
   static void computeDirichletAlphaDistribution(int policySize, const float* policyProbs, double* alphaDistr);
   static void addDirichletNoise(const SearchParams& searchParams, Rand& rand, int policySize, float* policyProbs);
 

--- a/cpp/search/search.h
+++ b/cpp/search/search.h
@@ -132,7 +132,7 @@ public:
 
 // Records info about a playout; used when queryMoveLoc != Board::NULL_LOC
 struct SearchPlayoutRecord {
-  long playoutIdx;
+  int64_t playoutIdx;
   double queryMoveSelectionProb;
   std::vector<Loc> visitedMoves;
 

--- a/cpp/search/searchparams.cpp
+++ b/cpp/search/searchparams.cpp
@@ -48,6 +48,7 @@ std::string SearchParams::getSearchAlgoAsStr() const {
 SearchParams::SearchParams()
   :passingBehavior(PassingBehavior::Standard),
    forceWinningPass(false),
+   queryMoveLoc(Board::NULL_LOC),
    searchAlgo(SearchAlgorithm::MCTS),
    canPassFirst(true),
    winLossUtilityFactor(1.0),

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -27,6 +27,7 @@ struct SearchParams {
   PassingBehavior passingBehavior;
   // If enabled, then we will definitely pass if it wins us the game.
   bool forceWinningPass;
+  Loc queryMoveLoc; // Move whose selection prob history we're logging; NULL_LOC if none
 
   // Algorithm to use for search
   enum class SearchAlgorithm { MCTS, EMCTS1 };

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1823,24 +1823,25 @@ bool Search::getAnalysisJson(
         utilityLcb = -utilityLcb;
       }
 
-    json moveInfo;
-    // This only depends on the size of the board, which is invariant, so it's fine to use the root board here
-    moveInfo["move"] = Location::toString(data.move, board);
-    moveInfo["visits"] = data.numVisits;
-    moveInfo["utility"] = roundDynamic(utility,OUTPUT_PRECISION);
-    moveInfo["resultUtility"] = roundDynamic(data.resultUtility,OUTPUT_PRECISION);
-    moveInfo["scoreUtility"] = roundDynamic(data.scoreUtility,OUTPUT_PRECISION);
-    moveInfo["winrate"] = roundDynamic(winrate,OUTPUT_PRECISION);
-    moveInfo["scoreMean"] = roundDynamic(lead,OUTPUT_PRECISION);
-    moveInfo["scoreSelfplay"] = roundDynamic(scoreMean,OUTPUT_PRECISION);
-    moveInfo["scoreLead"] = roundDynamic(lead,OUTPUT_PRECISION);
-    moveInfo["scoreStdev"] = roundDynamic(data.scoreStdev,OUTPUT_PRECISION);
-    moveInfo["prior"] = roundDynamic(data.policyPrior,OUTPUT_PRECISION);
-    moveInfo["lcb"] = roundDynamic(lcb,OUTPUT_PRECISION);
-    moveInfo["utilityLcb"] = roundDynamic(utilityLcb,OUTPUT_PRECISION);
-    moveInfo["order"] = data.order;
-    if(data.isSymmetryOf != Board::NULL_LOC)
-      moveInfo["isSymmetryOf"] = Location::toString(data.isSymmetryOf, board);
+      json moveInfo;
+      moveInfo["lcb"] = roundDynamic(lcb,OUTPUT_PRECISION);
+      // This only depends on the size of the board, which is invariant, so it's fine to use the root board here
+      moveInfo["move"] = Location::toString(data.move, board);
+      moveInfo["order"] = data.order;
+      moveInfo["prior"] = roundDynamic(data.policyPrior,OUTPUT_PRECISION);
+      moveInfo["resultUtility"] = roundDynamic(data.resultUtility,OUTPUT_PRECISION);
+      moveInfo["selectionValue"] = roundDynamic(data.playSelectionValue,OUTPUT_PRECISION);
+      moveInfo["scoreLead"] = roundDynamic(lead,OUTPUT_PRECISION);
+      moveInfo["scoreMean"] = roundDynamic(lead,OUTPUT_PRECISION);
+      moveInfo["scoreSelfplay"] = roundDynamic(scoreMean,OUTPUT_PRECISION);
+      moveInfo["scoreStdev"] = roundDynamic(data.scoreStdev,OUTPUT_PRECISION);
+      moveInfo["scoreUtility"] = roundDynamic(data.scoreUtility,OUTPUT_PRECISION);
+      moveInfo["utility"] = roundDynamic(utility,OUTPUT_PRECISION);
+      moveInfo["utilityLcb"] = roundDynamic(utilityLcb,OUTPUT_PRECISION);
+      moveInfo["visits"] = data.numVisits;
+      moveInfo["winrate"] = roundDynamic(winrate,OUTPUT_PRECISION);
+      if(data.isSymmetryOf != Board::NULL_LOC)
+        moveInfo["isSymmetryOf"] = Location::toString(data.isSymmetryOf, board);
 
       json pv = json::array();
       int pvLen =

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1804,6 +1804,8 @@ bool Search::getAnalysisJson(
     moveInfo["move"] = Location::toString(data.move, board);
     moveInfo["visits"] = data.numVisits;
     moveInfo["utility"] = roundDynamic(utility,OUTPUT_PRECISION);
+    moveInfo["resultUtility"] = roundDynamic(data.resultUtility,OUTPUT_PRECISION);
+    moveInfo["scoreUtility"] = roundDynamic(data.scoreUtility,OUTPUT_PRECISION);
     moveInfo["winrate"] = roundDynamic(winrate,OUTPUT_PRECISION);
     moveInfo["scoreMean"] = roundDynamic(lead,OUTPUT_PRECISION);
     moveInfo["scoreSelfplay"] = roundDynamic(scoreMean,OUTPUT_PRECISION);

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1082,12 +1082,12 @@ void Search::getAnalysisData(
   );
 
   vector<MoreNodeStats> statsBuf(numChildren);
-  double selectionProbs[Board::MAX_ARR_SIZE];
+  std::vector<double> selectionProbs(playSelectionValues.size());
 
   double temp = interpolateEarly(
     searchParams.chosenMoveTemperatureHalflife, searchParams.chosenMoveTemperatureEarly, searchParams.chosenMoveTemperature
   );
-  temperatureScaleProbs(playSelectionValues.data(), numChildren, temp, selectionProbs);
+  temperatureScaleProbs(playSelectionValues.data(), playSelectionValues.size(), temp, selectionProbs.data());
 
   for(int i = 0; i<numChildren; i++) {
     const SearchNode* child = children[i];

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1889,6 +1889,16 @@ bool Search::getAnalysisJson(
   };
   ret["moveInfos"] = build(rootNode, build);
 
+  // Selection prob history for query move
+  if(searchParams.queryMoveLoc != Board::NULL_LOC) {
+    json probHistory = json::array();
+    for(double prob : selectionProbHistory)
+      probHistory.push_back(roundDynamic(prob,OUTPUT_PRECISION));
+
+    ret["queryMove"] = Location::toString(searchParams.queryMoveLoc, board);
+    ret["selectionProbHistory"] = probHistory;
+  }
+
   // Stats for root position
   {
     ReportedSearchValues rootVals;


### PR DESCRIPTION
When KataGo selects a move, it first calls `Search::getPlaySelectionValues` to compute a weighted visit count for each top-level node in the MCTS tree. By default, with `useLcbForSelection=true`, these visit counts are also perturbed by adding a bonus to the move that has the highest lower confidence bound on its expected utility. These selection values are then passed to `Search::chooseIndexWithTemperature`, which scales the values by a dynamically-computed temperature that, by default, is 0.75 early in the game and is annealed to 0.15 in later stages. Finally, these scaled selection values are normalized into a probability distribution inside `Rand::nextUInt`, and the final move selection is made by randomly sampling from this distribution.

In the current codebase, this final temperature-scaled play selection value distribution (I'm calling it the `selectionProb` distribution) is never logged anywhere, and it's only computed after the tree search is complete. But for interpretability and debugging purposes it's probably quite useful to see what the `selectionProbs` _would_ be, _if_ we early-exited from the MCTS after each playout— very similar to how the [logit lens](https://www.lesswrong.com/posts/AcKRB8wDpdaN6v6ru/interpreting-gpt-the-logit-lens) reveals a language model's best-guess prediction at each layer of the network.

This PR implements the logit lens for KataGo's MCTS. It can be used in two ways. For `match` and `victimplay`, you can set the config option `trackPassProb=true`. This will add an extra field to the comments inside the logged sgfs, `prob_pass_hist`, which contains a tuple of floats indicating the selection prob of passing after each playout leading up to a move. Secondly, in the `analysis` command, you can add a `queryMoves` field containing a list of moves whose selection prob history you'd like to track. Right now you can only track one move at a time, but I'll lift this limitation soon if it looks like it'd be useful for interpretability work.