### PR TITLE
evaluate_loop: Don't error if predictor is not specified

### DIFF
--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -9,7 +9,7 @@ then
 fi
 
 BASE_DIR="$1"
-PREDICTOR_DIR="$2"
+PREDICTOR_DIR=${2:-}
 MODELS_DIR="$BASE_DIR"/models
 VICTIMS_DIR="$BASE_DIR"/victims
 OUTPUT_DIR="$BASE_DIR"/eval


### PR DESCRIPTION
Fixes the following error that occurs if the optional `$PREDICTOR` positional argument is not provided:
* `/engines/KataGo-custom/cpp/evaluate_loop.sh: line 12: $2: unbound variable`