### PR TITLE
cpp/setup: Add `oppVisitsOverride` to allow bounded A-MCTS-R

### DIFF
--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -379,6 +379,9 @@ vector<SearchParams> Setup::loadParams(
     if(cfg.contains("searchAlgorithm"+idxStr)) params.searchAlgo = SearchParams::strToSearchAlgo(cfg.getString("searchAlgorithm"+idxStr));
     else if (cfg.contains("searchAlgorithm"))  params.searchAlgo = SearchParams::strToSearchAlgo(cfg.getString("searchAlgorithm"));
 
+    if(cfg.contains("oppVisitsOverride"+idxStr)) params.oppVisitsOverride = cfg.getInt64("oppVisitsOverride"+idxStr, (int64_t)1, (int64_t)1 << 50);
+    else if (cfg.contains("oppVisitsOverride"))  params.oppVisitsOverride = cfg.getInt64("oppVisitsOverride",        (int64_t)1, (int64_t)1 << 50);
+
     if(cfg.contains("canPassFirst"+idxStr)) params.canPassFirst = cfg.getBool("canPassFirst"+idxStr);
 
     if(cfg.contains("maxPlayouts"+idxStr)) params.maxPlayouts = cfg.getInt64("maxPlayouts"+idxStr, (int64_t)1, (int64_t)1 << 50);

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -507,7 +507,9 @@ Search::Search(
     assert(oppNNEval != nullptr);
     assert(!oppParams.usingAdversarialAlgo());
 
-    oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R ? oppParams.maxVisits : 1;
+    oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
+      ? params.oppVisitsOverride.value_or(oppParams.maxVisits)
+      : 1;
     oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
     oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
   }

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -46,6 +46,9 @@ struct SearchParams {
   std::string getSearchAlgoAsStr() const;
   bool usingAdversarialAlgo() const;
 
+  // Overrides the number of vists we use in AMCTS-R to simulate the victim.
+  std::optional<int> oppVisitsOverride;
+
   // Whether we are allowed to be the first player that passes in a game.
   bool canPassFirst;
 

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -46,7 +46,7 @@ struct SearchParams {
   std::string getSearchAlgoAsStr() const;
   bool usingAdversarialAlgo() const;
 
-  // Overrides the number of vists we use in AMCTS-R to simulate the victim.
+  // Overrides the number of visits we use in AMCTS-R to simulate the victim.
   std::optional<int> oppVisitsOverride;
 
   // Whether we are allowed to be the first player that passes in a game.


### PR DESCRIPTION
* Add `oppVisitsOverride` (previously removed by PR #67) to allow bounded A-MCTS-R