### PR TITLE
gatekeeper: Make gatekeeping work for victimplay

### DIFF
--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -296,7 +296,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
   try {
     KataGoCommandLine cmd("Test neural nets to see if they should be accepted for self-play training data generation.");
     cmd.addConfigFileArg("","");
-    cmd.addOverrideConfigArg()
+    cmd.addOverrideConfigArg();
 
     TCLAP::ValueArg<string> testModelsDirArg("","test-models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",true,string(),"DIR");

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -379,6 +379,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
 
   Setup::initializeSession(cfg);
   vector<SearchParams> paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
+  vector<SearchParams> originalParamss = paramss;
   if (victimplay) assert(1 <= paramss.size() && paramss.size() <= 2);
   else assert(paramss.size() == 1);
 
@@ -662,7 +663,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
           // Update `paramss` with the new victim config.
           logger.write("Old victim config:\n" + lastAcceptedModelResults.victimCfgContents);
           logger.write("Reloading with config:\n" + victimCfgContents);
-          paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
+          paramss = originalParamss;
           Setup::loadParams(
               victimCfg,
               Setup::SETUP_FOR_OTHER,

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -758,11 +758,10 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
 
       string renameDest = acceptedModelsDir + "/" + testModelInfo->name;
       logger.write(
-          "Accepting model" + testModelInfo->name
+          "Accepting model " + testModelInfo->name
           + "; moving " + testModelInfo->dir + " to " + renameDest);
       FileUtils::rename(testModelInfo->dir,renameDest);
     } else if (testModelInfo.has_value()) {
-      logger.write(Global::strprintf("Rejecting model %s", testModelInfo->name));
       string renameDest = rejectedModelsDir + "/" + testModelInfo->name;
       logger.write(
           "Rejecting model " + testModelInfo->name

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -296,6 +296,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
   try {
     KataGoCommandLine cmd("Test neural nets to see if they should be accepted for self-play training data generation.");
     cmd.addConfigFileArg("","");
+    cmd.addOverrideConfigArg()
 
     TCLAP::ValueArg<string> testModelsDirArg("","test-models-dir","Dir to poll and load models from",true,string(),"DIR");
     TCLAP::ValueArg<string> sgfOutputDirArg("","sgf-output-dir","Dir to output sgf files",true,string(),"DIR");

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -627,7 +627,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
 
     bool shouldAcceptTestModel = false;
     if (victimplay) {
-      const optional<ModelFileInfo> victimModelInfo = getLatestModelInfo(
+      optional<ModelFileInfo> victimModelInfo = getLatestModelInfo(
           logger,
           victimModelsDir,
           false /*allowRandomNet*/,
@@ -638,6 +638,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
         sleep(4);
         continue;
       }
+      victimModelInfo->name = "victim-" + victimModelInfo->name;
       string victimCfgContents;
       ConfigParser victimCfg;
       if(FileUtils::exists(victimCfgReloadPath)) {

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -205,7 +205,7 @@ namespace {
 //-----------------------------------------------------------------------------------------
 
 
-int MainCmds::gatekeeper(const vector<string>& args) {
+int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
   Board::initHash();
   ScoreValue::initTables();
   Rand seedRand;
@@ -328,6 +328,26 @@ int MainCmds::gatekeeper(const vector<string>& args) {
     Logger::logThreadUncaught("data write loop", &logger, dataWriteLoop);
   };
 
+  // TODO(tomtseng)
+  // the plan:
+  // * pull finding the latest model out of loadLatestNeuralNet
+  // * pull moving model into rejected out of loadLatestNeuralNet
+  // * loading victim cfg in selfplay: you need to move that out to a common
+  //   file because you need to reuse it here. Maybe check the shasum to
+  //   determine whether to refresh the victim?
+  //   * add function called updateParams in setup.h?
+  //     - oof this kinda sucks, ideally we want to log every extra assignment?
+  //       Maybe we just have updateParams() print out the whole config file
+  // * move the actual evaluation stuff out of the while(true) loop b/c we need
+  // to reuse it
+  //
+  // * steps:
+  // *  - find latest test, accepted
+  // *  - if acceptedTime > testTime then reject automatically
+  // *  - find latest victim + victim config
+  // *  - if <acceptedName, victimName, victimCfg.getContents()> are different from
+  //      before, then compute accepted vs. victim
+  // *  - compute test vs. victim, keep the better one
   auto loadLatestNeuralNet =
     [&testModelsDir,&rejectedModelsDir,&acceptedModelsDir,&sgfOutputDir,&logger,&cfg,numGameThreads,noAutoRejectOldModels,
      minBoardXSizeUsed,maxBoardXSizeUsed,minBoardYSizeUsed,maxBoardYSizeUsed]() -> NetAndStuff* {

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -638,7 +638,12 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
         // Update `paramss` with the new victim config.
         logger.write("Old victim config:\n" + lastAcceptedModelResults.victimCfgContents);
         logger.write("Reloading with config:\n" + victimCfgContents);
-        Setup::loadParams(victimCfg, Setup::SETUP_FOR_OTHER, &paramss);
+        Setup::loadParams(
+            victimCfg,
+            Setup::SETUP_FOR_OTHER,
+            &paramss,
+            false /*applyDefaultParams*/
+        );
         victimCfg.warnUnusedKeys(cerr, &logger);
       }
 

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -353,6 +353,8 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
   MakeDir::make(acceptedModelsDir);
   MakeDir::make(rejectedModelsDir);
   MakeDir::make(sgfOutputDir);
+  if (victimModelsDir != "")
+    MakeDir::make(victimModelsDir);
   if(selfplayDir != "")
     MakeDir::make(selfplayDir);
 
@@ -603,7 +605,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
         true /*allowRandomNet*/
     );
     if (!acceptedModelInfo.has_value()) {
-      logger.write("Error: No accepted model found in " + acceptedModelsDir);
+      logger.write("No accepted model found in " + acceptedModelsDir);
       sleep(4);
       continue;
     }
@@ -631,7 +633,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
           false /*checkDirsOnly*/
       );
       if (!victimModelInfo.has_value()) {
-        logger.write("Error: No victim model found in " + victimModelsDir);
+        logger.write("No victim model found in " + victimModelsDir);
         sleep(4);
         continue;
       }

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -667,7 +667,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
           Setup::loadParams(
               victimCfg,
               Setup::SETUP_FOR_OTHER,
-              &paramss,
+              paramss,
               false /*applyDefaultParams*/
           );
           victimCfg.warnUnusedKeys(cerr, &logger);

--- a/cpp/command/gatekeeper.cpp
+++ b/cpp/command/gatekeeper.cpp
@@ -662,6 +662,7 @@ int MainCmds::gatekeeper(const vector<string>& args, bool victimplay) {
           // Update `paramss` with the new victim config.
           logger.write("Old victim config:\n" + lastAcceptedModelResults.victimCfgContents);
           logger.write("Reloading with config:\n" + victimCfgContents);
+          paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
           Setup::loadParams(
               victimCfg,
               Setup::SETUP_FOR_OTHER,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -476,7 +476,6 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     &gameRunner,
     &manager,
     &logger,
-    &cfg,
     switchNetsMidGame,
     &numGamesStarted,
     &forkData,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -475,6 +475,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     &gameRunner,
     &manager,
     &logger,
+    &cfg,
     switchNetsMidGame,
     &numGamesStarted,
     &forkData,
@@ -528,8 +529,9 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
               lock_guard<mutex> lock(paramsReloadMutex);
               std::string victimCfgContents = victimCfg.getAllKeyVals();
               if (victimCfgContents != lastVictimCfgContents) {
-                logger.write("Old config:\n" + lastVictimCfgContents);
+                logger.write("Old victim config:\n" + lastVictimCfgContents);
                 logger.write("Reloading with config:\n" + victimCfgContents);
+                paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
                 Setup::loadParams(
                     victimCfg,
                     Setup::SETUP_FOR_OTHER,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -185,6 +185,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
   assert(!(victimplay && switchNetsMidGame));
 
   vector<SearchParams> paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
+  const vector<SearchParams> originalParamss = paramss;
   if (victimplay) assert(1 <= paramss.size() && paramss.size() <= 2);
   else assert(paramss.size() == 1);
 
@@ -481,6 +482,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     &forkData,
     maxGamesTotal,
     &paramss,
+    &originalParamss,
     &baseParams,
     &paramsReloadMutex,
     &gameSeedBase,
@@ -531,7 +533,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
               if (victimCfgContents != lastVictimCfgContents) {
                 logger.write("Old victim config:\n" + lastVictimCfgContents);
                 logger.write("Reloading with config:\n" + victimCfgContents);
-                paramss = Setup::loadParams(cfg, Setup::SETUP_FOR_OTHER);
+                paramss = originalParamss;
                 Setup::loadParams(
                     victimCfg,
                     Setup::SETUP_FOR_OTHER,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -537,7 +537,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
                 Setup::loadParams(
                     victimCfg,
                     Setup::SETUP_FOR_OTHER,
-                    &paramss,
+                    paramss,
                     false /*applyDefaultParams*/
                 );
                 victimCfg.warnUnusedKeys(cerr, &logger);

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -530,7 +530,12 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
               if (victimCfgContents != lastVictimCfgContents) {
                 logger.write("Old config:\n" + lastVictimCfgContents);
                 logger.write("Reloading with config:\n" + victimCfgContents);
-                Setup::loadParams(victimCfg, Setup::SETUP_FOR_OTHER, &paramss);
+                Setup::loadParams(
+                    victimCfg,
+                    Setup::SETUP_FOR_OTHER,
+                    &paramss,
+                    false /*applyDefaultParams*/
+                );
                 victimCfg.warnUnusedKeys(cerr, &logger);
                 lastVictimCfgContents = std::move(victimCfgContents);
               }

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -41,7 +41,9 @@ tuner : (OpenCL only) Run tuning to find and optimize parameters that work on yo
 ---Selfplay training subcommands---------
 
 selfplay : Play selfplay games and generate training data.
-gatekeeper : Poll directory for new nets and match them against the latest net so far.
+victimplay : Play victimplay games and generate training data.
+gatekeeper : Poll directory for new nets and match them against the latest net so far. (selfplay only)
+victimplaygatekeeper : Same as gatekeeper, but for victimplay.
 
 ---Testing/debugging subcommands-------------
 evalsgf : Utility/debug tool, analyze a single position of a game from an SGF file.
@@ -75,6 +77,8 @@ static int handleSubcommand(const string& subcommand, const vector<string>& args
     return MainCmds::evalsgf(subArgs);
   else if(subcommand == "gatekeeper")
     return MainCmds::gatekeeper(subArgs);
+  else if(subcommand == "victimplaygatekeeper")
+    return MainCmds::gatekeeper(subArgs, true);
   else if(subcommand == "genconfig")
     return MainCmds::genconfig(subArgs,args[0]);
   else if(subcommand == "gtp")

--- a/cpp/main.h
+++ b/cpp/main.h
@@ -5,7 +5,7 @@ namespace MainCmds {
   int benchmark(const std::vector<std::string>& args);
   int contribute(const std::vector<std::string>& args);
   int evalsgf(const std::vector<std::string>& args);
-  int gatekeeper(const std::vector<std::string>& args);
+  int gatekeeper(const std::vector<std::string>& args, bool victimplay = false);
   int genconfig(const std::vector<std::string>& args, const std::string& firstCommand);
   int gtp(const std::vector<std::string>& args);
   int tuner(const std::vector<std::string>& args);

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -356,14 +356,24 @@ vector<SearchParams> Setup::loadParams(
   ConfigParser& cfg,
   setup_for_t setupFor
 ) {
-
   vector<SearchParams> paramss;
+  loadParams(cfg, setupFor, &paramss);
+  return paramss;
+}
+
+void Setup::loadParams(
+  ConfigParser& cfg,
+  setup_for_t setupFor,
+  vector<SearchParams>* paramss
+) {
+  assert(paramss != nullptr);
   int numBots = 1;
   if(cfg.contains("numBots"))
     numBots = cfg.getInt("numBots",1,MAX_BOT_PARAMS_FROM_CFG);
+  paramss->resize(numBots);
 
   for(int i = 0; i<numBots; i++) {
-    SearchParams params;
+    SearchParams& params = (*paramss)[i];
 
     string idxStr = Global::intToString(i);
 
@@ -657,10 +667,8 @@ vector<SearchParams> Setup::loadParams(
     else                                             params.futileVisitsThreshold = 0.0;
 
 
-    paramss.push_back(params);
+    paramss->push_back(params);
   }
-
-  return paramss;
 }
 
 Player Setup::parseReportAnalysisWinrates(

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -420,7 +420,7 @@ void Setup::loadParams(
     else if(cfg.contains("searchFactorAfterTwoPass"))   params.searchFactorAfterTwoPass = cfg.getDouble("searchFactorAfterTwoPass",        0.0, 1.0);
 
     if(cfg.contains("numSearchThreads"+idxStr)) params.numThreads = cfg.getInt("numSearchThreads"+idxStr, 1, 4096);
-    else if(applyDefaultParams)                 params.numThreads = cfg.getInt("numSearchThreads",        1, 4096);
+    else if(cfg.contains("numSearchThreads"))   params.numThreads = cfg.getInt("numSearchThreads",        1, 4096);
 
     if(cfg.contains("winLossUtilityFactor"+idxStr)) params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor"+idxStr, 0.0, 1.0);
     else if(cfg.contains("winLossUtilityFactor"))   params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor",        0.0, 1.0);

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -364,7 +364,8 @@ vector<SearchParams> Setup::loadParams(
 void Setup::loadParams(
   ConfigParser& cfg,
   setup_for_t setupFor,
-  vector<SearchParams>* paramss
+  vector<SearchParams>* paramss,
+  bool applyDefaultParams
 ) {
   assert(paramss != nullptr);
   int numBots = 1;
@@ -379,7 +380,7 @@ void Setup::loadParams(
 
     if(cfg.contains("trackPassProb"+idxStr)) params.queryMoveLoc = cfg.getBool("trackPassProb"+idxStr) ? Board::PASS_LOC : Board::NULL_LOC;
     else if (cfg.contains("trackPassProb"))  params.queryMoveLoc = cfg.getBool("trackPassProb") ? Board::PASS_LOC : Board::NULL_LOC;
-    else params.queryMoveLoc = Board::NULL_LOC;
+    else if(applyDefaultParams)              params.queryMoveLoc = Board::NULL_LOC;
 
     if(cfg.contains("passingBehavior"+idxStr)) params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"+idxStr));
     else if (cfg.contains("passingBehavior"))  params.passingBehavior = SearchParams::strToPassingBehavior(cfg.getString("passingBehavior"));
@@ -400,17 +401,17 @@ void Setup::loadParams(
 
     if(cfg.contains("maxPlayoutsPondering"+idxStr)) params.maxPlayoutsPondering = cfg.getInt64("maxPlayoutsPondering"+idxStr, (int64_t)1, (int64_t)1 << 50);
     else if(cfg.contains("maxPlayoutsPondering"))   params.maxPlayoutsPondering = cfg.getInt64("maxPlayoutsPondering",        (int64_t)1, (int64_t)1 << 50);
-    else                                            params.maxPlayoutsPondering = (int64_t)1 << 50;
+    else if(applyDefaultParams)                     params.maxPlayoutsPondering = (int64_t)1 << 50;
     if(cfg.contains("maxVisitsPondering"+idxStr)) params.maxVisitsPondering = cfg.getInt64("maxVisitsPondering"+idxStr, (int64_t)1, (int64_t)1 << 50);
     else if(cfg.contains("maxVisitsPondering"))   params.maxVisitsPondering = cfg.getInt64("maxVisitsPondering",        (int64_t)1, (int64_t)1 << 50);
-    else                                          params.maxVisitsPondering = (int64_t)1 << 50;
+    else if(applyDefaultParams)                   params.maxVisitsPondering = (int64_t)1 << 50;
     if(cfg.contains("maxTimePondering"+idxStr)) params.maxTimePondering = cfg.getDouble("maxTimePondering"+idxStr, 0.0, 1.0e20);
     else if(cfg.contains("maxTimePondering"))   params.maxTimePondering = cfg.getDouble("maxTimePondering",        0.0, 1.0e20);
-    else                                        params.maxTimePondering = 1.0e20;
+    else if(applyDefaultParams)                 params.maxTimePondering = 1.0e20;
 
     if(cfg.contains("lagBuffer"+idxStr)) params.lagBuffer = cfg.getDouble("lagBuffer"+idxStr, 0.0, 3600.0);
     else if(cfg.contains("lagBuffer"))   params.lagBuffer = cfg.getDouble("lagBuffer",        0.0, 3600.0);
-    else                                 params.lagBuffer = 0.0;
+    else if(applyDefaultParams)          params.lagBuffer = 0.0;
 
     if(cfg.contains("searchFactorAfterOnePass"+idxStr)) params.searchFactorAfterOnePass = cfg.getDouble("searchFactorAfterOnePass"+idxStr, 0.0, 1.0);
     else if(cfg.contains("searchFactorAfterOnePass"))   params.searchFactorAfterOnePass = cfg.getDouble("searchFactorAfterOnePass",        0.0, 1.0);
@@ -418,256 +419,253 @@ void Setup::loadParams(
     else if(cfg.contains("searchFactorAfterTwoPass"))   params.searchFactorAfterTwoPass = cfg.getDouble("searchFactorAfterTwoPass",        0.0, 1.0);
 
     if(cfg.contains("numSearchThreads"+idxStr)) params.numThreads = cfg.getInt("numSearchThreads"+idxStr, 1, 4096);
-    else                                        params.numThreads = cfg.getInt("numSearchThreads",        1, 4096);
+    else if(applyDefaultParams)                 params.numThreads = cfg.getInt("numSearchThreads",        1, 4096);
 
     if(cfg.contains("winLossUtilityFactor"+idxStr)) params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor"+idxStr, 0.0, 1.0);
     else if(cfg.contains("winLossUtilityFactor"))   params.winLossUtilityFactor = cfg.getDouble("winLossUtilityFactor",        0.0, 1.0);
-    else                                            params.winLossUtilityFactor = 1.0;
+    else if(applyDefaultParams)                     params.winLossUtilityFactor = 1.0;
     if(cfg.contains("staticScoreUtilityFactor"+idxStr)) params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor"+idxStr, 0.0, 1.0);
     else if(cfg.contains("staticScoreUtilityFactor"))   params.staticScoreUtilityFactor = cfg.getDouble("staticScoreUtilityFactor",        0.0, 1.0);
-    else                                                params.staticScoreUtilityFactor = 0.1;
+    else if(applyDefaultParams)                         params.staticScoreUtilityFactor = 0.1;
     if(cfg.contains("dynamicScoreUtilityFactor"+idxStr)) params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor"+idxStr, 0.0, 1.0);
     else if(cfg.contains("dynamicScoreUtilityFactor"))   params.dynamicScoreUtilityFactor = cfg.getDouble("dynamicScoreUtilityFactor",        0.0, 1.0);
-    else                                                 params.dynamicScoreUtilityFactor = 0.3;
+    else if(applyDefaultParams)                          params.dynamicScoreUtilityFactor = 0.3;
     if(cfg.contains("noResultUtilityForWhite"+idxStr)) params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite"+idxStr, -1.0, 1.0);
     else if(cfg.contains("noResultUtilityForWhite"))   params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite",        -1.0, 1.0);
-    else                                               params.noResultUtilityForWhite = 0.0;
+    else if(applyDefaultParams)                        params.noResultUtilityForWhite = 0.0;
     if(cfg.contains("drawEquivalentWinsForWhite"+idxStr)) params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite"+idxStr, 0.0, 1.0);
     else if(cfg.contains("drawEquivalentWinsForWhite"))   params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite",        0.0, 1.0);
-    else                                                  params.drawEquivalentWinsForWhite = 0.5;
+    else if(applyDefaultParams)                           params.drawEquivalentWinsForWhite = 0.5;
 
     if(cfg.contains("dynamicScoreCenterZeroWeight"+idxStr)) params.dynamicScoreCenterZeroWeight = cfg.getDouble("dynamicScoreCenterZeroWeight"+idxStr, 0.0, 1.0);
     else if(cfg.contains("dynamicScoreCenterZeroWeight"))   params.dynamicScoreCenterZeroWeight = cfg.getDouble("dynamicScoreCenterZeroWeight",        0.0, 1.0);
-    else params.dynamicScoreCenterZeroWeight = 0.20;
+    else if(applyDefaultParams)                             params.dynamicScoreCenterZeroWeight = 0.20;
     if(cfg.contains("dynamicScoreCenterScale"+idxStr)) params.dynamicScoreCenterScale = cfg.getDouble("dynamicScoreCenterScale"+idxStr, 0.2, 5.0);
     else if(cfg.contains("dynamicScoreCenterScale"))   params.dynamicScoreCenterScale = cfg.getDouble("dynamicScoreCenterScale",        0.2, 5.0);
-    else params.dynamicScoreCenterScale = 0.75;
+    else if(applyDefaultParams)                        params.dynamicScoreCenterScale = 0.75;
 
     if(cfg.contains("cpuctExploration"+idxStr)) params.cpuctExploration = cfg.getDouble("cpuctExploration"+idxStr, 0.0, 10.0);
     else if(cfg.contains("cpuctExploration"))   params.cpuctExploration = cfg.getDouble("cpuctExploration",        0.0, 10.0);
-    else                                        params.cpuctExploration = 1.0;
+    else if(applyDefaultParams)                 params.cpuctExploration = 1.0;
     if(cfg.contains("cpuctExplorationLog"+idxStr)) params.cpuctExplorationLog = cfg.getDouble("cpuctExplorationLog"+idxStr, 0.0, 10.0);
     else if(cfg.contains("cpuctExplorationLog"))   params.cpuctExplorationLog = cfg.getDouble("cpuctExplorationLog",        0.0, 10.0);
-    else                                           params.cpuctExplorationLog = 0.45;
+    else if(applyDefaultParams)                    params.cpuctExplorationLog = 0.45;
     if(cfg.contains("cpuctExplorationBase"+idxStr)) params.cpuctExplorationBase = cfg.getDouble("cpuctExplorationBase"+idxStr, 10.0, 100000.0);
     else if(cfg.contains("cpuctExplorationBase"))   params.cpuctExplorationBase = cfg.getDouble("cpuctExplorationBase",        10.0, 100000.0);
-    else                                            params.cpuctExplorationBase = 500.0;
+    else if(applyDefaultParams)                     params.cpuctExplorationBase = 500.0;
 
     if(cfg.contains("cpuctUtilityStdevPrior"+idxStr)) params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior"+idxStr, 0.0, 10.0);
     else if(cfg.contains("cpuctUtilityStdevPrior"))   params.cpuctUtilityStdevPrior = cfg.getDouble("cpuctUtilityStdevPrior",        0.0, 10.0);
-    else                                              params.cpuctUtilityStdevPrior = 0.40;
+    else if(applyDefaultParams)                       params.cpuctUtilityStdevPrior = 0.40;
     if(cfg.contains("cpuctUtilityStdevPriorWeight"+idxStr)) params.cpuctUtilityStdevPriorWeight = cfg.getDouble("cpuctUtilityStdevPriorWeight"+idxStr, 0.0, 100.0);
     else if(cfg.contains("cpuctUtilityStdevPriorWeight"))   params.cpuctUtilityStdevPriorWeight = cfg.getDouble("cpuctUtilityStdevPriorWeight",        0.0, 100.0);
-    else                                                    params.cpuctUtilityStdevPriorWeight = 2.0;
+    else if(applyDefaultParams)                             params.cpuctUtilityStdevPriorWeight = 2.0;
     if(cfg.contains("cpuctUtilityStdevScale"+idxStr)) params.cpuctUtilityStdevScale = cfg.getDouble("cpuctUtilityStdevScale"+idxStr, 0.0, 1.0);
     else if(cfg.contains("cpuctUtilityStdevScale"))   params.cpuctUtilityStdevScale = cfg.getDouble("cpuctUtilityStdevScale",        0.0, 1.0);
-    else                                              params.cpuctUtilityStdevScale = ((setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER) ? 0.85 : 0.0);
+    else if(applyDefaultParams)                       params.cpuctUtilityStdevScale = ((setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER) ? 0.85 : 0.0);
 
 
     if(cfg.contains("fpuReductionMax"+idxStr)) params.fpuReductionMax = cfg.getDouble("fpuReductionMax"+idxStr, 0.0, 2.0);
     else if(cfg.contains("fpuReductionMax"))   params.fpuReductionMax = cfg.getDouble("fpuReductionMax",        0.0, 2.0);
-    else params.fpuReductionMax = 0.2;
+    else if(applyDefaultParams)                params.fpuReductionMax = 0.2;
     if(cfg.contains("fpuLossProp"+idxStr)) params.fpuLossProp = cfg.getDouble("fpuLossProp"+idxStr, 0.0, 1.0);
     else if(cfg.contains("fpuLossProp"))   params.fpuLossProp = cfg.getDouble("fpuLossProp",        0.0, 1.0);
-    else                                   params.fpuLossProp = 0.0;
+    else if(applyDefaultParams)            params.fpuLossProp = 0.0;
     if(cfg.contains("fpuParentWeight"+idxStr)) params.fpuParentWeight = cfg.getDouble("fpuParentWeight"+idxStr,        0.0, 1.0);
     else if(cfg.contains("fpuParentWeight"))   params.fpuParentWeight = cfg.getDouble("fpuParentWeight",        0.0, 1.0);
-    else                                       params.fpuParentWeight = 0.0;
+    else if(applyDefaultParams)                params.fpuParentWeight = 0.0;
 
 
     if(cfg.contains("valueWeightExponent"+idxStr)) params.valueWeightExponent = cfg.getDouble("valueWeightExponent"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("valueWeightExponent")) params.valueWeightExponent = cfg.getDouble("valueWeightExponent", 0.0, 1.0);
-    else params.valueWeightExponent = 0.5;
+    else if(cfg.contains("valueWeightExponent"))   params.valueWeightExponent = cfg.getDouble("valueWeightExponent", 0.0, 1.0);
+    else if(applyDefaultParams)                    params.valueWeightExponent = 0.5;
     if(cfg.contains("useNoisePruning"+idxStr)) params.useNoisePruning = cfg.getBool("useNoisePruning"+idxStr);
     else if(cfg.contains("useNoisePruning"))   params.useNoisePruning = cfg.getBool("useNoisePruning");
-    else                                       params.useNoisePruning = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
+    else if(applyDefaultParams)                params.useNoisePruning = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
     if(cfg.contains("noisePruneUtilityScale"+idxStr)) params.noisePruneUtilityScale = cfg.getDouble("noisePruneUtilityScale"+idxStr, 0.001, 10.0);
     else if(cfg.contains("noisePruneUtilityScale"))   params.noisePruneUtilityScale = cfg.getDouble("noisePruneUtilityScale", 0.001, 10.0);
-    else                                              params.noisePruneUtilityScale = 0.15;
+    else if(applyDefaultParams)                       params.noisePruneUtilityScale = 0.15;
     if(cfg.contains("noisePruningCap"+idxStr)) params.noisePruningCap = cfg.getDouble("noisePruningCap"+idxStr, 0.0, 1e50);
     else if(cfg.contains("noisePruningCap"))   params.noisePruningCap = cfg.getDouble("noisePruningCap", 0.0, 1e50);
-    else                                       params.noisePruningCap = 1e50;
+    else if(applyDefaultParams)                params.noisePruningCap = 1e50;
 
 
     if(cfg.contains("useUncertainty"+idxStr)) params.useUncertainty = cfg.getBool("useUncertainty"+idxStr);
     else if(cfg.contains("useUncertainty"))   params.useUncertainty = cfg.getBool("useUncertainty");
-    else                                      params.useUncertainty = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
+    else if(applyDefaultParams)               params.useUncertainty = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
     if(cfg.contains("uncertaintyCoeff"+idxStr)) params.uncertaintyCoeff = cfg.getDouble("uncertaintyCoeff"+idxStr, 0.0001, 1.0);
     else if(cfg.contains("uncertaintyCoeff"))   params.uncertaintyCoeff = cfg.getDouble("uncertaintyCoeff", 0.0001, 1.0);
-    else                                        params.uncertaintyCoeff = 0.25;
+    else if(applyDefaultParams)                 params.uncertaintyCoeff = 0.25;
     if(cfg.contains("uncertaintyExponent"+idxStr)) params.uncertaintyExponent = cfg.getDouble("uncertaintyExponent"+idxStr, 0.0, 2.0);
     else if(cfg.contains("uncertaintyExponent"))   params.uncertaintyExponent = cfg.getDouble("uncertaintyExponent", 0.0, 2.0);
-    else                                           params.uncertaintyExponent = 1.0;
+    else if(applyDefaultParams)                    params.uncertaintyExponent = 1.0;
     if(cfg.contains("uncertaintyMaxWeight"+idxStr)) params.uncertaintyMaxWeight = cfg.getDouble("uncertaintyMaxWeight"+idxStr, 1.0, 100.0);
     else if(cfg.contains("uncertaintyMaxWeight"))   params.uncertaintyMaxWeight = cfg.getDouble("uncertaintyMaxWeight", 1.0, 100.0);
-    else                                            params.uncertaintyMaxWeight = 8.0;
+    else if(applyDefaultParams)                     params.uncertaintyMaxWeight = 8.0;
 
 
     if(cfg.contains("rootNoiseEnabled"+idxStr)) params.rootNoiseEnabled = cfg.getBool("rootNoiseEnabled"+idxStr);
     else if(cfg.contains("rootNoiseEnabled"))   params.rootNoiseEnabled = cfg.getBool("rootNoiseEnabled");
-    else                                        params.rootNoiseEnabled = false;
+    else if(applyDefaultParams)                 params.rootNoiseEnabled = false;
     if(cfg.contains("rootDirichletNoiseTotalConcentration"+idxStr))
       params.rootDirichletNoiseTotalConcentration = cfg.getDouble("rootDirichletNoiseTotalConcentration"+idxStr, 0.001, 10000.0);
     else if(cfg.contains("rootDirichletNoiseTotalConcentration"))
       params.rootDirichletNoiseTotalConcentration = cfg.getDouble("rootDirichletNoiseTotalConcentration", 0.001, 10000.0);
-    else
+    else if(applyDefaultParams)
       params.rootDirichletNoiseTotalConcentration = 10.83;
     if(cfg.contains("rootDirichletNoiseWeight"+idxStr)) params.rootDirichletNoiseWeight = cfg.getDouble("rootDirichletNoiseWeight"+idxStr, 0.0, 1.0);
     else if(cfg.contains("rootDirichletNoiseWeight"))   params.rootDirichletNoiseWeight = cfg.getDouble("rootDirichletNoiseWeight",        0.0, 1.0);
-    else                                                params.rootDirichletNoiseWeight = 0.25;
+    else if(applyDefaultParams)                         params.rootDirichletNoiseWeight = 0.25;
 
     if(cfg.contains("rootPolicyTemperature"+idxStr)) params.rootPolicyTemperature = cfg.getDouble("rootPolicyTemperature"+idxStr, 0.01, 100.0);
     else if(cfg.contains("rootPolicyTemperature"))   params.rootPolicyTemperature = cfg.getDouble("rootPolicyTemperature",        0.01, 100.0);
-    else                                             params.rootPolicyTemperature = 1.0;
+    else if(applyDefaultParams)                      params.rootPolicyTemperature = 1.0;
     if(cfg.contains("rootPolicyTemperatureEarly"+idxStr)) params.rootPolicyTemperatureEarly = cfg.getDouble("rootPolicyTemperatureEarly"+idxStr, 0.01, 100.0);
     else if(cfg.contains("rootPolicyTemperatureEarly"))   params.rootPolicyTemperatureEarly = cfg.getDouble("rootPolicyTemperatureEarly",        0.01, 100.0);
-    else                                                  params.rootPolicyTemperatureEarly = params.rootPolicyTemperature;
+    else if(applyDefaultParams)                           params.rootPolicyTemperatureEarly = params.rootPolicyTemperature;
     if(cfg.contains("rootFpuReductionMax"+idxStr)) params.rootFpuReductionMax = cfg.getDouble("rootFpuReductionMax"+idxStr, 0.0, 2.0);
     else if(cfg.contains("rootFpuReductionMax"))   params.rootFpuReductionMax = cfg.getDouble("rootFpuReductionMax",        0.0, 2.0);
-    else                                           params.rootFpuReductionMax = params.rootNoiseEnabled ? 0.0 : 0.1;
+    else if(applyDefaultParams)                    params.rootFpuReductionMax = params.rootNoiseEnabled ? 0.0 : 0.1;
     if(cfg.contains("rootFpuLossProp"+idxStr)) params.rootFpuLossProp = cfg.getDouble("rootFpuLossProp"+idxStr, 0.0, 1.0);
     else if(cfg.contains("rootFpuLossProp"))   params.rootFpuLossProp = cfg.getDouble("rootFpuLossProp",        0.0, 1.0);
-    else                                       params.rootFpuLossProp = params.fpuLossProp;
+    else if(applyDefaultParams)                params.rootFpuLossProp = params.fpuLossProp;
     if(cfg.contains("rootNumSymmetriesToSample"+idxStr)) params.rootNumSymmetriesToSample = cfg.getInt("rootNumSymmetriesToSample"+idxStr, 1, SymmetryHelpers::NUM_SYMMETRIES);
     else if(cfg.contains("rootNumSymmetriesToSample"))   params.rootNumSymmetriesToSample = cfg.getInt("rootNumSymmetriesToSample",        1, SymmetryHelpers::NUM_SYMMETRIES);
-    else                                                 params.rootNumSymmetriesToSample = 1;
+    else if(applyDefaultParams)                          params.rootNumSymmetriesToSample = 1;
     if(cfg.contains("rootSymmetryPruning"+idxStr)) params.rootSymmetryPruning = cfg.getBool("rootSymmetryPruning"+idxStr);
     else if(cfg.contains("rootSymmetryPruning"))   params.rootSymmetryPruning = cfg.getBool("rootSymmetryPruning");
-    else                                           params.rootSymmetryPruning = (setupFor == SETUP_FOR_ANALYSIS || setupFor == SETUP_FOR_GTP);
+    else if(applyDefaultParams)                    params.rootSymmetryPruning = (setupFor == SETUP_FOR_ANALYSIS || setupFor == SETUP_FOR_GTP);
 
     if(cfg.contains("rootDesiredPerChildVisitsCoeff"+idxStr)) params.rootDesiredPerChildVisitsCoeff = cfg.getDouble("rootDesiredPerChildVisitsCoeff"+idxStr, 0.0, 100.0);
     else if(cfg.contains("rootDesiredPerChildVisitsCoeff"))   params.rootDesiredPerChildVisitsCoeff = cfg.getDouble("rootDesiredPerChildVisitsCoeff",        0.0, 100.0);
-    else                                                      params.rootDesiredPerChildVisitsCoeff = 0.0;
+    else if(applyDefaultParams)                               params.rootDesiredPerChildVisitsCoeff = 0.0;
 
     if(cfg.contains("chosenMoveTemperature"+idxStr)) params.chosenMoveTemperature = cfg.getDouble("chosenMoveTemperature"+idxStr, 0.0, 5.0);
     else if(cfg.contains("chosenMoveTemperature"))   params.chosenMoveTemperature = cfg.getDouble("chosenMoveTemperature",        0.0, 5.0);
-    else                                             params.chosenMoveTemperature = 0.1;
+    else if(applyDefaultParams)                      params.chosenMoveTemperature = 0.1;
     if(cfg.contains("chosenMoveTemperatureEarly"+idxStr))
       params.chosenMoveTemperatureEarly = cfg.getDouble("chosenMoveTemperatureEarly"+idxStr, 0.0, 5.0);
     else if(cfg.contains("chosenMoveTemperatureEarly"))
       params.chosenMoveTemperatureEarly = cfg.getDouble("chosenMoveTemperatureEarly",        0.0, 5.0);
-    else
+    else if(applyDefaultParams)
       params.chosenMoveTemperatureEarly = 0.5;
     if(cfg.contains("chosenMoveTemperatureHalflife"+idxStr))
       params.chosenMoveTemperatureHalflife = cfg.getDouble("chosenMoveTemperatureHalflife"+idxStr, 0.1, 100000.0);
     else if(cfg.contains("chosenMoveTemperatureHalflife"))
       params.chosenMoveTemperatureHalflife = cfg.getDouble("chosenMoveTemperatureHalflife",        0.1, 100000.0);
-    else
+    else if(applyDefaultParams)
       params.chosenMoveTemperatureHalflife = 19;
     if(cfg.contains("chosenMoveSubtract"+idxStr)) params.chosenMoveSubtract = cfg.getDouble("chosenMoveSubtract"+idxStr, 0.0, 1.0e10);
     else if(cfg.contains("chosenMoveSubtract"))   params.chosenMoveSubtract = cfg.getDouble("chosenMoveSubtract",        0.0, 1.0e10);
-    else                                          params.chosenMoveSubtract = 0.0;
+    else if(applyDefaultParams)                   params.chosenMoveSubtract = 0.0;
     if(cfg.contains("chosenMovePrune"+idxStr)) params.chosenMovePrune = cfg.getDouble("chosenMovePrune"+idxStr, 0.0, 1.0e10);
     else if(cfg.contains("chosenMovePrune"))   params.chosenMovePrune = cfg.getDouble("chosenMovePrune",        0.0, 1.0e10);
-    else                                       params.chosenMovePrune = 1.0;
+    else if(applyDefaultParams)                params.chosenMovePrune = 1.0;
 
     if(cfg.contains("useLcbForSelection"+idxStr)) params.useLcbForSelection = cfg.getBool("useLcbForSelection"+idxStr);
     else if(cfg.contains("useLcbForSelection"))   params.useLcbForSelection = cfg.getBool("useLcbForSelection");
-    else                                          params.useLcbForSelection = true;
+    else if(applyDefaultParams)                   params.useLcbForSelection = true;
 
     if(cfg.contains("useLcbForSelfplayMove"+idxStr)) params.useLcbForSelfplayMove = cfg.getBool("useLcbForSelfplayMove"+idxStr);
     else if(cfg.contains("useLcbForSelfplayMove"))   params.useLcbForSelfplayMove = cfg.getBool("useLcbForSelfplayMove");
-    else                                             params.useLcbForSelfplayMove = false;
+    else if(applyDefaultParams)                      params.useLcbForSelfplayMove = false;
 
     if(cfg.contains("lcbStdevs"+idxStr)) params.lcbStdevs = cfg.getDouble("lcbStdevs"+idxStr, 1.0, 12.0);
     else if(cfg.contains("lcbStdevs"))   params.lcbStdevs = cfg.getDouble("lcbStdevs",        1.0, 12.0);
-    else                                 params.lcbStdevs = 5.0;
+    else if(applyDefaultParams)          params.lcbStdevs = 5.0;
     if(cfg.contains("minVisitPropForLCB"+idxStr)) params.minVisitPropForLCB = cfg.getDouble("minVisitPropForLCB"+idxStr, 0.0, 1.0);
     else if(cfg.contains("minVisitPropForLCB"))   params.minVisitPropForLCB = cfg.getDouble("minVisitPropForLCB",        0.0, 1.0);
-    else                                          params.minVisitPropForLCB = 0.15;
+    else if(applyDefaultParams)                   params.minVisitPropForLCB = 0.15;
     //For distributed and selfplay, we default to buggy LCB for the moment since it has effects on the policy training target.
     if(cfg.contains("useNonBuggyLcb"+idxStr)) params.useNonBuggyLcb = cfg.getBool("useNonBuggyLcb"+idxStr);
     else if(cfg.contains("useNonBuggyLcb"))   params.useNonBuggyLcb = cfg.getBool("useNonBuggyLcb");
-    else                                      params.useNonBuggyLcb = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
+    else if(applyDefaultParams)               params.useNonBuggyLcb = (setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER);
 
 
     if(cfg.contains("rootEndingBonusPoints"+idxStr)) params.rootEndingBonusPoints = cfg.getDouble("rootEndingBonusPoints"+idxStr, -1.0, 1.0);
     else if(cfg.contains("rootEndingBonusPoints"))   params.rootEndingBonusPoints = cfg.getDouble("rootEndingBonusPoints",        -1.0, 1.0);
-    else                                             params.rootEndingBonusPoints = 0.5;
+    else if(applyDefaultParams)                      params.rootEndingBonusPoints = 0.5;
     if(cfg.contains("rootPruneUselessMoves"+idxStr)) params.rootPruneUselessMoves = cfg.getBool("rootPruneUselessMoves"+idxStr);
     else if(cfg.contains("rootPruneUselessMoves"))   params.rootPruneUselessMoves = cfg.getBool("rootPruneUselessMoves");
-    else                                             params.rootPruneUselessMoves = true;
+    else if(applyDefaultParams)                      params.rootPruneUselessMoves = true;
     if(cfg.contains("conservativePass"+idxStr)) params.conservativePass = cfg.getBool("conservativePass"+idxStr);
     else if(cfg.contains("conservativePass"))   params.conservativePass = cfg.getBool("conservativePass");
-    else                                        params.conservativePass = false;
+    else if(applyDefaultParams)                 params.conservativePass = false;
     if(cfg.contains("fillDameBeforePass"+idxStr)) params.fillDameBeforePass = cfg.getBool("fillDameBeforePass"+idxStr);
     else if(cfg.contains("fillDameBeforePass"))   params.fillDameBeforePass = cfg.getBool("fillDameBeforePass");
-    else                                          params.fillDameBeforePass = false;
+    else if(applyDefaultParams)                   params.fillDameBeforePass = false;
     //Controlled by GTP directly, not used in any other mode
     params.avoidMYTDaggerHackPla = C_EMPTY;
     if(cfg.contains("wideRootNoise"+idxStr)) params.wideRootNoise = cfg.getDouble("wideRootNoise"+idxStr, 0.0, 5.0);
     else if(cfg.contains("wideRootNoise"))   params.wideRootNoise = cfg.getDouble("wideRootNoise", 0.0, 5.0);
-    else                                     params.wideRootNoise = (setupFor == SETUP_FOR_ANALYSIS ? Setup::DEFAULT_ANALYSIS_WIDE_ROOT_NOISE : 0.00);
+    else if(applyDefaultParams)              params.wideRootNoise = (setupFor == SETUP_FOR_ANALYSIS ? Setup::DEFAULT_ANALYSIS_WIDE_ROOT_NOISE : 0.00);
 
     if(cfg.contains("playoutDoublingAdvantage"+idxStr)) params.playoutDoublingAdvantage = cfg.getDouble("playoutDoublingAdvantage"+idxStr,-3.0,3.0);
     else if(cfg.contains("playoutDoublingAdvantage"))   params.playoutDoublingAdvantage = cfg.getDouble("playoutDoublingAdvantage",-3.0,3.0);
-    else                                                params.playoutDoublingAdvantage = 0.0;
+    else if(applyDefaultParams)                         params.playoutDoublingAdvantage = 0.0;
     if(cfg.contains("playoutDoublingAdvantagePla"+idxStr)) params.playoutDoublingAdvantagePla = parsePlayer("playoutDoublingAdvantagePla",cfg.getString("playoutDoublingAdvantagePla"+idxStr));
     else if(cfg.contains("playoutDoublingAdvantagePla"))   params.playoutDoublingAdvantagePla = parsePlayer("playoutDoublingAdvantagePla",cfg.getString("playoutDoublingAdvantagePla"));
-    else                                                   params.playoutDoublingAdvantagePla = C_EMPTY;
+    else if(applyDefaultParams)                            params.playoutDoublingAdvantagePla = C_EMPTY;
 
     if(cfg.contains("avoidRepeatedPatternUtility"+idxStr)) params.avoidRepeatedPatternUtility = cfg.getDouble("avoidRepeatedPatternUtility"+idxStr, -3.0, 3.0);
     else if(cfg.contains("avoidRepeatedPatternUtility"))   params.avoidRepeatedPatternUtility = cfg.getDouble("avoidRepeatedPatternUtility", -3.0, 3.0);
-    else                                                   params.avoidRepeatedPatternUtility = 0.0;
+    else if(applyDefaultParams)                            params.avoidRepeatedPatternUtility = 0.0;
 
     if(cfg.contains("nnPolicyTemperature"+idxStr))
       params.nnPolicyTemperature = cfg.getFloat("nnPolicyTemperature"+idxStr,0.01f,5.0f);
     else if(cfg.contains("nnPolicyTemperature"))
       params.nnPolicyTemperature = cfg.getFloat("nnPolicyTemperature",0.01f,5.0f);
-    else
+    else if(applyDefaultParams)
       params.nnPolicyTemperature = 1.0f;
 
     if(cfg.contains("antiMirror"+idxStr)) params.antiMirror = cfg.getBool("antiMirror"+idxStr);
     else if(cfg.contains("antiMirror"))   params.antiMirror = cfg.getBool("antiMirror");
-    else                                  params.antiMirror = false;
+    else if(applyDefaultParams)           params.antiMirror = false;
 
     if(cfg.contains("subtreeValueBiasFactor"+idxStr)) params.subtreeValueBiasFactor = cfg.getDouble("subtreeValueBiasFactor"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("subtreeValueBiasFactor")) params.subtreeValueBiasFactor = cfg.getDouble("subtreeValueBiasFactor", 0.0, 1.0);
-    else params.subtreeValueBiasFactor = 0.35;
+    else if(cfg.contains("subtreeValueBiasFactor"))   params.subtreeValueBiasFactor = cfg.getDouble("subtreeValueBiasFactor", 0.0, 1.0);
+    else if(applyDefaultParams)                       params.subtreeValueBiasFactor = 0.35;
     if(cfg.contains("subtreeValueBiasFreeProp"+idxStr)) params.subtreeValueBiasFreeProp = cfg.getDouble("subtreeValueBiasFreeProp"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("subtreeValueBiasFreeProp")) params.subtreeValueBiasFreeProp = cfg.getDouble("subtreeValueBiasFreeProp", 0.0, 1.0);
-    else params.subtreeValueBiasFreeProp = 0.8;
+    else if(cfg.contains("subtreeValueBiasFreeProp"))   params.subtreeValueBiasFreeProp = cfg.getDouble("subtreeValueBiasFreeProp", 0.0, 1.0);
+    else if(applyDefaultParams)                         params.subtreeValueBiasFreeProp = 0.8;
     if(cfg.contains("subtreeValueBiasWeightExponent"+idxStr)) params.subtreeValueBiasWeightExponent = cfg.getDouble("subtreeValueBiasWeightExponent"+idxStr, 0.0, 1.0);
-    else if(cfg.contains("subtreeValueBiasWeightExponent")) params.subtreeValueBiasWeightExponent = cfg.getDouble("subtreeValueBiasWeightExponent", 0.0, 1.0);
-    else params.subtreeValueBiasWeightExponent = 0.8;
+    else if(cfg.contains("subtreeValueBiasWeightExponent"))   params.subtreeValueBiasWeightExponent = cfg.getDouble("subtreeValueBiasWeightExponent", 0.0, 1.0);
+    else if(applyDefaultParams)                               params.subtreeValueBiasWeightExponent = 0.8;
 
     if(cfg.contains("mutexPoolSize"+idxStr)) params.mutexPoolSize = (uint32_t)cfg.getInt("mutexPoolSize"+idxStr, 1, 1 << 24);
     else if(cfg.contains("mutexPoolSize"))   params.mutexPoolSize = (uint32_t)cfg.getInt("mutexPoolSize",        1, 1 << 24);
-    else                                     params.mutexPoolSize = 16384;
+    else if(applyDefaultParams)              params.mutexPoolSize = 16384;
     if(cfg.contains("numVirtualLossesPerThread"+idxStr)) params.numVirtualLossesPerThread = cfg.getDouble("numVirtualLossesPerThread"+idxStr, 0.01, 1000.0);
     else if(cfg.contains("numVirtualLossesPerThread"))   params.numVirtualLossesPerThread = cfg.getDouble("numVirtualLossesPerThread",        0.01, 1000.0);
-    else                                                 params.numVirtualLossesPerThread = 1.0;
+    else if(applyDefaultParams)                          params.numVirtualLossesPerThread = 1.0;
 
     if(cfg.contains("treeReuseCarryOverTimeFactor"+idxStr)) params.treeReuseCarryOverTimeFactor = cfg.getDouble("treeReuseCarryOverTimeFactor"+idxStr,0.0,1.0);
     else if(cfg.contains("treeReuseCarryOverTimeFactor"))   params.treeReuseCarryOverTimeFactor = cfg.getDouble("treeReuseCarryOverTimeFactor",0.0,1.0);
-    else                                                    params.treeReuseCarryOverTimeFactor = 0.0;
+    else if(applyDefaultParams)                             params.treeReuseCarryOverTimeFactor = 0.0;
     if(cfg.contains("overallocateTimeFactor"+idxStr)) params.overallocateTimeFactor = cfg.getDouble("overallocateTimeFactor"+idxStr,0.01,100.0);
     else if(cfg.contains("overallocateTimeFactor"))   params.overallocateTimeFactor = cfg.getDouble("overallocateTimeFactor",0.01,100.0);
-    else                                              params.overallocateTimeFactor = 1.0;
+    else if(applyDefaultParams)                       params.overallocateTimeFactor = 1.0;
     if(cfg.contains("midgameTimeFactor"+idxStr)) params.midgameTimeFactor = cfg.getDouble("midgameTimeFactor"+idxStr,0.01,100.0);
     else if(cfg.contains("midgameTimeFactor"))   params.midgameTimeFactor = cfg.getDouble("midgameTimeFactor",0.01,100.0);
-    else                                         params.midgameTimeFactor = 1.0;
+    else if(applyDefaultParams)                  params.midgameTimeFactor = 1.0;
     if(cfg.contains("midgameTurnPeakTime"+idxStr)) params.midgameTurnPeakTime = cfg.getDouble("midgameTurnPeakTime"+idxStr,0.0,1000.0);
     else if(cfg.contains("midgameTurnPeakTime"))   params.midgameTurnPeakTime = cfg.getDouble("midgameTurnPeakTime",0.0,1000.0);
-    else                                           params.midgameTurnPeakTime = 130.0;
+    else if(applyDefaultParams)                    params.midgameTurnPeakTime = 130.0;
     if(cfg.contains("endgameTurnTimeDecay"+idxStr)) params.endgameTurnTimeDecay = cfg.getDouble("endgameTurnTimeDecay"+idxStr,0.0,1000.0);
     else if(cfg.contains("endgameTurnTimeDecay"))   params.endgameTurnTimeDecay = cfg.getDouble("endgameTurnTimeDecay",0.0,1000.0);
-    else                                            params.endgameTurnTimeDecay = 100.0;
+    else if(applyDefaultParams)                     params.endgameTurnTimeDecay = 100.0;
     if(cfg.contains("obviousMovesTimeFactor"+idxStr)) params.obviousMovesTimeFactor = cfg.getDouble("obviousMovesTimeFactor"+idxStr,0.01,1.0);
     else if(cfg.contains("obviousMovesTimeFactor"))   params.obviousMovesTimeFactor = cfg.getDouble("obviousMovesTimeFactor",0.01,1.0);
-    else                                              params.obviousMovesTimeFactor = 1.0;
+    else if(applyDefaultParams)                       params.obviousMovesTimeFactor = 1.0;
     if(cfg.contains("obviousMovesPolicyEntropyTolerance"+idxStr)) params.obviousMovesPolicyEntropyTolerance = cfg.getDouble("obviousMovesPolicyEntropyTolerance"+idxStr,0.001,2.0);
     else if(cfg.contains("obviousMovesPolicyEntropyTolerance"))   params.obviousMovesPolicyEntropyTolerance = cfg.getDouble("obviousMovesPolicyEntropyTolerance",0.001,2.0);
-    else                                                          params.obviousMovesPolicyEntropyTolerance = 0.30;
+    else if(applyDefaultParams)                                   params.obviousMovesPolicyEntropyTolerance = 0.30;
     if(cfg.contains("obviousMovesPolicySurpriseTolerance"+idxStr)) params.obviousMovesPolicySurpriseTolerance = cfg.getDouble("obviousMovesPolicySurpriseTolerance"+idxStr,0.001,2.0);
     else if(cfg.contains("obviousMovesPolicySurpriseTolerance"))   params.obviousMovesPolicySurpriseTolerance = cfg.getDouble("obviousMovesPolicySurpriseTolerance",0.001,2.0);
-    else                                                           params.obviousMovesPolicySurpriseTolerance = 0.15;
+    else if(applyDefaultParams)                                    params.obviousMovesPolicySurpriseTolerance = 0.15;
     if(cfg.contains("futileVisitsThreshold"+idxStr)) params.futileVisitsThreshold = cfg.getDouble("futileVisitsThreshold"+idxStr,0.01,1.0);
     else if(cfg.contains("futileVisitsThreshold"))   params.futileVisitsThreshold = cfg.getDouble("futileVisitsThreshold",0.01,1.0);
-    else                                             params.futileVisitsThreshold = 0.0;
-
-
-    paramss->push_back(params);
+    else if(applyDefaultParams)                      params.futileVisitsThreshold = 0.0;
   }
 }
 

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -368,9 +368,10 @@ void Setup::loadParams(
   bool applyDefaultParams
 ) {
   assert(paramss != nullptr);
-  int numBots = 1;
+  int numBots = applyDefaultParams ? 1 : paramss->size();
   if(cfg.contains("numBots"))
     numBots = cfg.getInt("numBots",1,MAX_BOT_PARAMS_FROM_CFG);
+  assert(numBots > 0);
   paramss->resize(numBots);
 
   for(int i = 0; i<numBots; i++) {

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -357,25 +357,24 @@ vector<SearchParams> Setup::loadParams(
   setup_for_t setupFor
 ) {
   vector<SearchParams> paramss;
-  loadParams(cfg, setupFor, &paramss);
+  loadParams(cfg, setupFor, paramss);
   return paramss;
 }
 
 void Setup::loadParams(
   ConfigParser& cfg,
   setup_for_t setupFor,
-  vector<SearchParams>* paramss,
+  vector<SearchParams>& paramss,
   bool applyDefaultParams
 ) {
-  assert(paramss != nullptr);
-  int numBots = applyDefaultParams ? 1 : paramss->size();
+  int numBots = applyDefaultParams ? 1 : paramss.size();
   if(cfg.contains("numBots"))
     numBots = cfg.getInt("numBots",1,MAX_BOT_PARAMS_FROM_CFG);
   assert(numBots > 0);
-  paramss->resize(numBots);
+  paramss.resize(numBots);
 
   for(int i = 0; i<numBots; i++) {
-    SearchParams& params = (*paramss)[i];
+    SearchParams& params = paramss[i];
 
     string idxStr = Global::intToString(i);
 

--- a/cpp/program/setup.h
+++ b/cpp/program/setup.h
@@ -61,12 +61,16 @@ namespace Setup {
     ConfigParser& cfg,
     setup_for_t setupFor
   );
-  //Loads search parameters into `paramss`, keeping the parameter values already
-  //in `paramss` when they are not specified in the config.
+  //Loads search parameters into paramss.
+  //If applyDefaultParams is true, parameters not specified in the config are
+  //assigned a defualt value.
+  //If applyDefaultParams is false, parameters not specified in the config keep
+  //the value already present in paramss.
   void loadParams(
     ConfigParser& cfg,
     setup_for_t setupFor,
-    std::vector<SearchParams>* paramss
+    std::vector<SearchParams>* paramss,
+    bool applyDefaultParams = true
   );
   SearchParams loadSingleParams(
     ConfigParser& cfg,

--- a/cpp/program/setup.h
+++ b/cpp/program/setup.h
@@ -69,7 +69,7 @@ namespace Setup {
   void loadParams(
     ConfigParser& cfg,
     setup_for_t setupFor,
-    std::vector<SearchParams>* paramss,
+    std::vector<SearchParams>& paramss,
     bool applyDefaultParams = true
   );
   SearchParams loadSingleParams(

--- a/cpp/program/setup.h
+++ b/cpp/program/setup.h
@@ -61,6 +61,13 @@ namespace Setup {
     ConfigParser& cfg,
     setup_for_t setupFor
   );
+  //Loads search parameters into `paramss`, keeping the parameter values already
+  //in `paramss` when they are not specified in the config.
+  void loadParams(
+    ConfigParser& cfg,
+    setup_for_t setupFor,
+    std::vector<SearchParams>* paramss
+  );
   SearchParams loadSingleParams(
     ConfigParser& cfg,
     setup_for_t setupFor


### PR DESCRIPTION
## Description

Context: The gatekeeper works for selfplay by taking candidate models, playing them against the latest "accepted" model (where the first accepted model is a random `/dev/null` model), and accepting a candidate model if it wins more than the accepted model.

For victimplay, we don't want the gatekeeper to play two adversaries against each other. Instead, we want to play adversaries against the latest victim and compare how good they are at beating the victim.

Changes:
* Add `victimplaygatekeeper` KataGo command that tests candidate models by playing it against the latest victim and checking if it performs better than the accepted model does against the latest victim. 

## Testing

* sanity check with some manual testing that the selfplay gatekeeper still works:
```sh
docker run --gpus '"device=7"' -v ~/go_attack:/go_attack  -v ~/gatekeep-scratch:/out  -it humancompatibleai/goattack:cpp
./engines/KataGo-custom/cpp/katago gatekeeper \
  -config /go_attack/configs/amcts/gatekeeper.cfg  \
  -config /go_attack/configs/compute/1gpu.cfg \
  -override-config numBots=1,maxVisits0=1 \
  -rejected-models-dir /out/rejected/ \
  -accepted-models-dir /out/accepted \
  -test-models-dir /out/test/ \
  -sgf-output-dir /out/output/ \
  -selfplay-dir /out/selfplay/ 
# Then move some models into ~/gatekeep-scratch/test and make sure models
# are played against each other, accepted, and rejected
```
* Do some similar manual testing to check that the victimplay gatekeeper executes as expected when new test models appear, new victim models appear, and when the victim config file changes
* Run victimplay training run with gating (go_attack PR: https://github.com/HumanCompatibleAI/go_attack/pull/84), check gatekeeper works