### PR TITLE
evaluate_loop: Don't allow victim.cfg to be the victim

### DIFF
--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -82,7 +82,7 @@ do
     if [[ -z "$VICTIM_LIST" ]]
     then
         # https://stackoverflow.com/questions/1015678/get-most-recent-file-in-a-directory-on-linux
-        VICTIM_LIST=$(ls -Art "$VICTIMS_DIR" | tail -n 1)
+        VICTIM_LIST=$(ls -Art "$VICTIMS_DIR" | grep "\.gz" | tail --lines 1)
     fi
 
     # Split the string VICTIM_LIST into an array victim_array:


### PR DESCRIPTION
If `victim.cfg` is the latest file in `<training-dir>/models/`, then `evaluate_loop.sh` will erroneously pick `victim.cfg` as the victim. This PR makes `evaluate_loop.sh` filter `models/` so as to not pick `victim.cfg`.