### PR TITLE
gtp: Check maxVisits0 for time control

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -1684,7 +1684,13 @@ int MainCmds::gtp(const vector<string>& args) {
   engine->setOrResetBoardSize(cfg,logger,seedRand,defaultBoardXSize,defaultBoardYSize,logger.isLoggingToStderr());
 
   //If nobody specified any time limit in any way, then assume a relatively fast time control
-  if(!cfg.contains("maxPlayouts") && !cfg.contains("maxVisits") && !cfg.contains("maxTime")) {
+  if(!cfg.contains("maxPlayouts")
+      && !cfg.contains("maxPlayouts0")
+      && !cfg.contains("maxVisits")
+      && !cfg.contains("maxVisits0")
+      && !cfg.contains("maxTime")
+      && !cfg.contains("maxTime0")
+  ) {
     double mainTime = 1.0;
     double byoYomiTime = 5.0;
     int byoYomiPeriods = 5;


### PR DESCRIPTION
I had an issue with GTP where I had set `maxVisits0` to a high number but only saw visit counts around ~4000 when I turned on `logSearchInfo = true`. 

Fix: Don't set the automatic time control if `maxVisits0` exists.