### PR TITLE
searchresults: Stricter pass hardening against seki situations

### DIFF
--- a/cpp/game/board.cpp
+++ b/cpp/game/board.cpp
@@ -469,7 +469,7 @@ bool Board::isLegalIgnoringKo(Loc loc, Player pla, bool isMultiStoneSuicideLegal
 }
 
 //Check if this location contains a simple eye for the specified player.
-bool Board::isSimpleEye(Loc loc, Player pla) const
+bool Board::isSimpleEye(Loc loc, Player pla, bool allowFalseEye) const
 {
   if(colors[loc] != C_EMPTY)
     return false;
@@ -484,6 +484,10 @@ bool Board::isSimpleEye(Loc loc, Player pla) const
       against_wall = true;
     else if(colors[adj] != pla)
       return false;
+  }
+
+  if (allowFalseEye) {
+    return true;
   }
 
   //Check that opponent does not own too many diagonal points

--- a/cpp/game/board.h
+++ b/cpp/game/board.h
@@ -195,7 +195,8 @@ struct Board
   //Check if this location is on the board
   bool isOnBoard(Loc loc) const;
   //Check if this location contains a simple eye for the specified player.
-  bool isSimpleEye(Loc loc, Player pla) const;
+  //Returns true for false eyes as well if allowFalseEye is true.
+  bool isSimpleEye(Loc loc, Player pla, bool allowFalseEye = false) const;
   //Check if a move at this location would be a capture of an opponent group.
   bool wouldBeCapture(Loc loc, Player pla) const;
   //Check if a move at this location would be a capture in a simple ko mouth.

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -626,9 +626,11 @@ bool Search::shouldSuppressPass(const SearchNode* n) const {
           if(!rootHistory.isLegalModuloPassing(rootBoard, loc, rootPla))
             continue;
 
-          // Found a legal move that isn't in our own pass-alive territory.
-          // This means we should not pass, i.e. passing should be suppressed.
-          if(!playersMatch(territories[loc], rootPla)) {
+          // Found a legal move that isn't in our own pass-alive territory,
+          // isn't one of our eyes, and won't put the location in atari.
+          if(!playersMatch(territories[loc], rootPla)
+              && !rootBoard.isSimpleEye(loc, rootPla, true /*allowFalseEye*/)
+              && rootBoard.getNumLibertiesAfterPlay(loc, rootPla, 2) != 1) {
             return true;
           }
         }

--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -26,7 +26,9 @@ bool Search::shouldSuppressMove(
 ) const {
   return (suppressPass && moveLoc == Board::PASS_LOC)
     || (searchParams.passingBehavior == SearchParams::PassingBehavior::AvoidPassAliveTerritory
-        && playersMatch(passAliveTerritories[moveLoc], rootPla));
+        && (playersMatch(passAliveTerritories[moveLoc], rootPla)
+          || rootBoard.isSimpleEye(moveLoc, rootPla, true /*allowFalseEye*/)
+          || rootBoard.getNumLibertiesAfterPlay(moveLoc, rootPla, 2) <= 1));
 }
 
 bool Search::getPlaySelectionValues(
@@ -630,7 +632,7 @@ bool Search::shouldSuppressPass(const SearchNode* n) const {
           // isn't one of our eyes, and won't put the location in atari.
           if(!playersMatch(territories[loc], rootPla)
               && !rootBoard.isSimpleEye(loc, rootPla, true /*allowFalseEye*/)
-              && rootBoard.getNumLibertiesAfterPlay(loc, rootPla, 2) != 1) {
+              && rootBoard.getNumLibertiesAfterPlay(loc, rootPla, 2) > 1) {
             return true;
           }
         }


### PR DESCRIPTION
Kellin noticed that hardened victims play poorly in seki situations. The proposed fix: "one can pass if only legal moves are in own pass-alive territory, in a single space one surrounds, or put oneself in atari"

## Testing

ran a match using an adversary that usually wins against cp505h but loses against cp505. the result was that the adversary lost against both cp505 and cp505h, as desired (data: `/nas/ucb/k8/go-attack/match/ttseng-warm63-vs-cp505-seki-20230110-204209`)