### PR TITLE
Switch to new CircleCI custom GPU runner resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
     resource_class: xlarge
   cpp-gpu:
     machine: true
-    resource_class: humancompatibleai/go-attack-linux-gpu
+    resource_class: alignmentresearch/go-attack-linux-gpu
   python:
     <<: *defaults
     docker:


### PR DESCRIPTION
After transferring GH orgs, need new CircleCI runner