### PR TITLE
victimplay: Print victim config reload only once, not once for each thread

### DIFF
--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -485,6 +485,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     &originalParamss,
     &baseParams,
     &paramsReloadMutex,
+    &lastVictimCfgContents,
     &gameSeedBase,
     &victimplay,
     &reloadVictims,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -188,10 +188,11 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
   const vector<SearchParams> originalParamss = paramss;
   if (victimplay) assert(1 <= paramss.size() && paramss.size() <= 2);
   else assert(paramss.size() == 1);
-
   SearchParams baseParams = paramss[0];
-  mutex paramsReloadMutex;
   std::string lastVictimCfgContents = "";
+  // Multithreaded use of paramss and lastVictimCfgContents should be guarded
+  // with paramsReloadMutex to avoid races.
+  mutex paramsReloadMutex;
 
   //Initialize object for randomizing game settings and running games
   PlaySettings playSettings = PlaySettings::loadForSelfplay(cfg);

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -191,6 +191,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
 
   SearchParams baseParams = paramss[0];
   mutex paramsReloadMutex;
+  std::string lastVictimCfgContents = "";
 
   //Initialize object for randomizing game settings and running games
   PlaySettings playSettings = PlaySettings::loadForSelfplay(cfg);
@@ -502,7 +503,6 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     string prevModelName;
     Rand thisLoopSeedRand;
     std::string victimCfgReloadPath = nnVictimPath + "/victim.cfg";
-    std::string lastVictimCfgContents = "";
     std::string logPrefix = "Game loop thread " + to_string(threadIdx) + ": ";
     while(true) {
       if(shouldStop.load())


### PR DESCRIPTION
PR #74 updated the victimplay victim config reloading logic so that it could be reused for the gatekeeper. But I had a bug where if the config got updated, every game thread would try to load the config and print a message about the config getting updated. We only need one thread to load the config, and we only want to print the message once. (I thought I fixed this in PR #74, but maybe I forgot to push a commit.)

Changes:
* Only the first thread to notice the config change will load the config into `paramss` and print a message about the config getting updated