### PR TITLE
search: Fix `temperatureScaleProbs()` crashing on zero temperature

### DIFF
--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -1027,6 +1027,7 @@ void Search::temperatureScaleProbs(const double* relativeProbs, int numRelativeP
   }
   assert(maxValue > 0.0);
 
+  // Special case for zero temperature to avoid division by zero.
   if (temperature == 0.0) {
     for(int i = 0; i<numRelativeProbs; i++) {
       buf[i] = 0.0;

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -1018,11 +1018,22 @@ void Search::temperatureScaleProbs(const double* relativeProbs, int numRelativeP
   assert(numRelativeProbs <= Board::MAX_ARR_SIZE); //We're just doing this on the stack
 
   double maxValue = 0.0;
+  int maxValueIndex = 0;
   for(int i = 0; i<numRelativeProbs; i++) {
-    if(relativeProbs[i] > maxValue)
+    if(relativeProbs[i] > maxValue) {
       maxValue = relativeProbs[i];
+      maxValueIndex = i;
+    }
   }
   assert(maxValue > 0.0);
+
+  if (temperature == 0.0) {
+    for(int i = 0; i<numRelativeProbs; i++) {
+      buf[i] = 0.0;
+    }
+    buf[maxValueIndex] = 1.0;
+    return;
+  }
 
   double logMaxValue = log(maxValue);
   double sum = 0.0;


### PR DESCRIPTION
## Context

Running `runsearchtests.sh` hits the following assertion error:
```
katago: /engines/KataGo-custom/cpp/search/search.cpp:1041: static void Search::temperatureScaleProbs(const double*, int, double, double*, bool): Assertion `sum > 0.0' failed.
``` 

`temperatureScaleProbs()` is a function we added for logit lens. It fails in this manner when its `temperature` is zero because a division by `temperature` makes `sum` be `nan`.

## Changes

Special-case `temperatureScaleProbs()` to handle the `temperature == 0` case. The tests now run without crashing.