### PR TITLE
evaluate_loop.sh: Evaluate the first adversary if warmstarting

### DIFF
--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -68,7 +68,7 @@ if [ -z "$VICTIMS_DIR" ]; then
     VICTIMS_DIR="$BASE_DIR"/victims
 fi
 
-LAST_STEP=0
+LAST_STEP=-1
 SLEEP_INTERVAL=30
 while true
 do


### PR DESCRIPTION
If we warmstart, `evaluate_loop.sh` does not evaluate the first adversary, t0-s0-d0. This PR fixes that.
