### PR TITLE
search: Allow both bots to use AMCTS

### DIFF
--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -504,12 +504,14 @@ Search::Search(
 {
   if (searchParams.usingAdversarialAlgo()) {
     assert(searchParams.numThreads == 1); // We do not support multithreading with AMCTS (yet).
-    assert(oppNNEval != nullptr);
+    assert(oppNNEval != nullptr || searchParams.maxVisits == 1);
 
     oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
       ? params.oppVisitsOverride.value_or(oppParams.maxVisits)
       : 1;
-    assert(!oppParams.usingAdversarialAlgo() || oppParams.maxVisits == 1);
+    // We don't want to recursively model an opponent also using A-MCTS or else
+    // we'll have infinite recursion.
+    assert(!oppParams.usingAdversarialAlgo() || searchParams.maxVisits == 1 || oppParams.maxVisits == 1);
     oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
     oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
   }

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -513,7 +513,8 @@ Search::Search(
     // we'll have infinite recursion.
     assert(!oppParams.usingAdversarialAlgo() || searchParams.maxVisits == 1 || oppParams.maxVisits == 1);
     oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
-    oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
+    SearchParams oppOppParams = oppParams.usingAdversarialAlgo() ? searchParams : SearchParams();
+    oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model", oppOppParams);
   }
 
   assert(logger != NULL);

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -505,11 +505,11 @@ Search::Search(
   if (searchParams.usingAdversarialAlgo()) {
     assert(searchParams.numThreads == 1); // We do not support multithreading with AMCTS (yet).
     assert(oppNNEval != nullptr);
-    assert(!oppParams.usingAdversarialAlgo());
 
     oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
       ? params.oppVisitsOverride.value_or(oppParams.maxVisits)
       : 1;
+    assert(!oppParams.usingAdversarialAlgo() || oppParams.maxVisits == 1);
     oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
     oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
   }

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -513,8 +513,7 @@ Search::Search(
       // we'll have infinite recursion.
       assert(!oppParams.usingAdversarialAlgo() || oppParams.maxVisits == 1);
       oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
-      SearchParams oppOppParams = oppParams.usingAdversarialAlgo() ? searchParams : SearchParams();
-      oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model", oppOppParams);
+      oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
     }
   }
 


### PR DESCRIPTION
The assertion `assert(!oppParams.usingAdversarialAlgo())` fails when two AMCTS bots play against each other. We should allow AMCTS bots to play as long as they're not doing recursive modeling — we just want to avoid infinite recursion.