### PR TITLE
selfplay: Allow selfplay games during victimplay (for iterated adversarial training)

### DIFF
--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -364,8 +364,10 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
       firstFileRandMinProp, dataBoardLen, dataBoardLen, onlyWriteEvery, Global::uint64ToHexString(rand.nextUInt64())
     );
 
-    tdataWriter->forVictimPlay = victimplay;
-    vdataWriter->forVictimPlay = victimplay;
+    tdataWriter->forVictimplay = victimplay;
+    vdataWriter->forVictimplay = victimplay;
+    tDataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
+    vDataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
 
     tdataWriter->useAuxPolicyTarget = cfg.getBool("useAuxPolicyTarget");
     vdataWriter->useAuxPolicyTarget = cfg.getBool("useAuxPolicyTarget");

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -284,7 +284,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
 
   //Returns true if a new net was loaded.
   auto loadLatestNeuralNetIntoManager =
-    [inputsVersion,&manager,maxRowsPerTrainFile,maxRowsPerValFile,firstFileRandMinProp,dataBoardLen,
+    [inputsVersion,&manager,maxRowsPerTrainFile,maxRowsPerValFile,firstFileRandMinProp,dataBoardLen,selfplayProportion,
      &loadNN,
      &modelsDir,&outputDir,&victimOutputDir,&logger,&cfg,numGameThreads,victimplay,
      minBoardXSizeUsed,maxBoardXSizeUsed,minBoardYSizeUsed,maxBoardYSizeUsed](const string* lastNetName) -> bool {
@@ -373,8 +373,8 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
 
     tdataWriter->forVictimplay = victimplay;
     vdataWriter->forVictimplay = victimplay;
-    tDataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
-    vDataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
+    tdataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
+    vdataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
 
     tdataWriter->useAuxPolicyTarget = cfg.getBool("useAuxPolicyTarget");
     vdataWriter->useAuxPolicyTarget = cfg.getBool("useAuxPolicyTarget");
@@ -497,6 +497,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
     &manager,
     &logger,
     switchNetsMidGame,
+    selfplayProportion,
     &numGamesStarted,
     &forkData,
     maxGamesTotal,
@@ -652,8 +653,8 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
             "Game #" + Global::int64ToString(gameIdx) +
             " selfplay W - B score: " +
             Global::floatToString(gameData->finalWhiteMinusBlackScore()) +
-            "; adv_" + advSearchParams.getSearchAlgoAsStr() +
-                "@" + Global::intToString(advSearchParams.maxVisits)
+            "; adv_" + curAdvSearchParams.getSearchAlgoAsStr() +
+                "@" + Global::intToString(curAdvSearchParams.maxVisits)
           );
         }
       } else {

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -644,6 +644,8 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
           botSpecB.botName = nnEval->getModelName();
           botSpecB.nnEval = nnEval;
           botSpecB.baseParams = curAdvSearchParams;
+          // A-MCTS is not helpful during selfplay, so let's make selfplay games run MCTS.
+          botSpecB.baseParams.searchAlgo = SearchParams::SearchAlgorithm::MCTS;
           MatchPairer::BotSpec botSpecW = botSpecB;
           gameData = gameRunner->runGame(
             seed, botSpecB, botSpecW, forkData, NULL, logger,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -271,8 +271,11 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
       (!FileUtils::exists(nnVictimPath) && !Global::isSuffix(nnVictimPath, ".gz"))
       || FileUtils::isDirectory(nnVictimPath);
     if(isDirectory) {
+      // We load victims from a directory.
+      // A new victim is loaded every time a new victim shows up in the directory.
       reloadVictims = true;
     } else {
+      // A victim is loaded a single time from a file.
       singleVictim.reset(loadNN("victim", nnVictimPath));
       victimNNEvals.push_back(singleVictim);
     }

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -187,7 +187,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
   // Proportion of selfplay games to include during victimplay training.
   const bool selfplayProportion =
     cfg.contains("selfplayProportion") ?
-    cfg.getDouble("selfplayProportion") :
+    cfg.getDouble("selfplayProportion", 0.0, 1.0) :
     0.0;
   assert(victimplay || selfplayProportion == 0.0);
 
@@ -627,7 +627,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
       } else if(victimplay) {
         manager->countOneGameStarted(nnEval);
         const string seed = gameSeedBase + ":" + Global::uint64ToHexString(thisLoopSeedRand.nextUInt64());
-        if (thisLoopSeedRand.nextDouble() >= selfplayProportion) {
+        if (thisLoopSeedRand.nextDouble() >= selfplayProportion) {  // victimplay game
           gameData = runOneVictimplayGame(
             curVictimNNEval.get(), nnEval,
             curVictimSearchParams, curAdvSearchParams,

--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -185,7 +185,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
   assert(!(victimplay && switchNetsMidGame));
 
   // Proportion of selfplay games to include during victimplay training.
-  const bool selfplayProportion =
+  const double selfplayProportion =
     cfg.contains("selfplayProportion") ?
     cfg.getDouble("selfplayProportion", 0.0, 1.0) :
     0.0;

--- a/cpp/dataio/trainingwrite.cpp
+++ b/cpp/dataio/trainingwrite.cpp
@@ -996,7 +996,8 @@ void TrainingDataWriter::writeGame(const FinishedGameData& data) {
   Player victimPlayer = getVictimPlayerColor(data);
   const bool isVictimplayGame = forVictimplay && victimPlayer != P_NONE;
   if (forVictimplay) {
-    // When doing victimplay, exactly one side should be a victim.
+    // When doing victimplay, exactly one side should be a victim unless
+    // selfplay games are enabled.
     assert(isVictimplayGame || allowSelfplayInVictimplay);
   }
 

--- a/cpp/dataio/trainingwrite.cpp
+++ b/cpp/dataio/trainingwrite.cpp
@@ -994,9 +994,10 @@ void TrainingDataWriter::writeGame(const FinishedGameData& data) {
   Player nextPlayer = data.startPla;
 
   Player victimPlayer = getVictimPlayerColor(data);
-  if (forVictimPlay) {
+  const bool isVictimplayGame = forVictimplay && victimPlayer != P_NONE;
+  if (forVictimplay) {
     // When doing victimplay, exactly one side should be a victim.
-    assert(victimPlayer != P_NONE);
+    assert(isVictimplayGame || allowSelfplayInVictimplay);
   }
 
   //Write main game rows
@@ -1019,7 +1020,7 @@ void TrainingDataWriter::writeGame(const FinishedGameData& data) {
     }
 
     auto buffers = writeBuffers;
-    if (forVictimPlay && nextPlayer == victimPlayer) {
+    if (isVictimplayGame && nextPlayer == victimPlayer) {
       if (victimBuffers)
         buffers = victimBuffers;
       else
@@ -1072,7 +1073,7 @@ void TrainingDataWriter::writeGame(const FinishedGameData& data) {
     SidePosition* sp = data.sidePositions[i];
 
     auto buffers = writeBuffers;
-    if (forVictimPlay && sp->pla == victimPlayer) {
+    if (isVictimplayGame && sp->pla == victimPlayer) {
       // Skip writing data when it is victim to move and we're not writing victim data
       if (victimBuffers)
         buffers = victimBuffers;

--- a/cpp/dataio/trainingwrite.h
+++ b/cpp/dataio/trainingwrite.h
@@ -271,7 +271,7 @@ class TrainingDataWriter {
   int64_t numRowsInBuffer() const;
 
   bool forVictimplay = false;
-  // Allow selfplay games to occur even when forVictimPlay is true.
+  // If true, allows selfplay games to occur even when forVictimPlay is true.
   bool allowSelfplayInVictimplay = false;
   bool useAuxPolicyTarget = true;
 

--- a/cpp/dataio/trainingwrite.h
+++ b/cpp/dataio/trainingwrite.h
@@ -270,7 +270,9 @@ class TrainingDataWriter {
   bool isEmpty() const;
   int64_t numRowsInBuffer() const;
 
-  bool forVictimPlay = false;
+  bool forVictimplay = false;
+  // Allow selfplay games to occur even when forVictimPlay is true.
+  bool allowSelfplayInVictimplay = false;
   bool useAuxPolicyTarget = true;
 
  private:

--- a/cpp/evaluate_loop.sh
+++ b/cpp/evaluate_loop.sh
@@ -11,6 +11,9 @@ usage() {
     echo " OUTPUT_DIR The directory to output results to."
     echo
     echo "optional arguments:"
+    echo "  --config CONFIG"
+    echo "    KataGo match config."
+    echo "    Default: GO_ATTACK_ROOT/configs/match-1gpu.cfg"
     echo "  -v VICTIM_LIST, --victim-list VICTIM_LIST"
     echo "    A comma-separated list of models in VICTIM_DIR to use."
     echo "    If empty, the most recent model will be used."
@@ -40,6 +43,7 @@ GO_ATTACK_ROOT="/go_attack"
 while [ -n "${1-}" ]; do
   case $1 in
     -h|--help) usage; exit 0 ;;
+    --config) CONFIG="$2"; shift 2 ;;
     -v|--victim-list) VICTIM_LIST="$2"; shift 2 ;;
     -d|--victim-dir) VICTIMS_DIR="$2"; shift 2 ;;
     -p|--prediction-dir) PREDICTOR_DIR="$2"; shift 2 ;;
@@ -49,6 +53,7 @@ while [ -n "${1-}" ]; do
     *) break ;;
   esac
 done
+CONFIG=${CONFIG:-"$GO_ATTACK_ROOT"/configs/match-1gpu.cfg}
 
 NUM_POSITIONAL_ARGUMENTS=2
 if [ $# -ne ${NUM_POSITIONAL_ARGUMENTS} ]; then
@@ -117,7 +122,7 @@ do
                 # Run the evaluation
                 echo "Evaluating model $LATEST_MODEL_DIR against victim $VICTIM_NAME"
                 $KATAGO_BIN match \
-                    -config $GO_ATTACK_ROOT/configs/match-1gpu.cfg \
+                    -config "$CONFIG" \
                     -config "$VICTIMS_DIR"/victim.cfg \
                     -override-config "$EXTRA_CONFIG" \
                     -override-config nnModelFile0="$VICTIMS_DIR"/"$VICTIM" \

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -616,11 +616,12 @@ class Curriculum:
                     useful_files.add(sgf_file)
 
         # now have cur_games sorted from newer to older
-        logging.info(
-            "Got {} new games from {} files, ignored {} selfplay games".format(
-                len(cur_games), len(useful_files), num_selfplay_games
-            ),
+        games_log_message = (
+            f"Got {len(cur_games)} new games from {len(useful_files)} files"
         )
+        if num_selfplay_games > 0:
+            games_log_message += f", ignored {num_selfplay_games} selfplay games"
+        logging.info(games_log_message)
         for f in useful_files:
             logging.info("Useful SGF file: '{}'".format(str(f)))
 

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -198,7 +198,7 @@ def get_name_to_colors(game: sgf.Sgf_game) -> Dict[str, Color]:
 
 def is_selfplay_game(game: sgf.Sgf_game) -> bool:
     """Returns true if the game is a selfplay game for the adversary."""
-    player_names = get_name_to_colors(game).keys()
+    player_names = list(get_name_to_colors(game).keys())
     assert len(player_names) == 2
     if player_names[0] != player_names[1]:
         return False

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -190,16 +190,10 @@ def get_game_score(game: sgf.Sgf_game) -> Optional[float]:
     return win_score
 
 
-def get_name_to_colors(game: sgf.Sgf_game) -> Dict[str, Color]:
-    """Returns dict mapping player name to color."""
-    colors: Sequence[Color] = (Color.BLACK, Color.WHITE)
-    return {game.get_player_name(color.value.lower()): color for color in colors}
-
-
 def is_selfplay_game(game: sgf.Sgf_game) -> bool:
     """Returns true if the game is a selfplay game for the adversary."""
-    player_names = list(get_name_to_colors(game).keys())
-    assert len(player_names) == 2
+    colors: Sequence[Color] = (Color.BLACK, Color.WHITE)
+    player_names = [game.get_player_name(color.value.lower()) for color in colors]
     if player_names[0] != player_names[1]:
         return False
     if is_name_victim(player_names[0]):
@@ -211,7 +205,10 @@ def is_selfplay_game(game: sgf.Sgf_game) -> bool:
 
 def get_victim_adv_colors(game: sgf.Sgf_game) -> Tuple[str, Color, Color]:
     """Returns a tuple of victim name, victim color and adversary color."""
-    name_to_colors = get_name_to_colors(game)
+    colors: Sequence[Color] = (Color.BLACK, Color.WHITE)
+    name_to_colors: Mapping[str, Color] = {
+        game.get_player_name(color.value.lower()): color for color in colors
+    }
     victim_names = [name for name in name_to_colors.keys() if is_name_victim(name)]
     if len(victim_names) != 1:
         raise ValueError("Found '{len(victim_names)}' != 1 victims: %s", victim_names)

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -192,7 +192,7 @@ def get_game_score(game: sgf.Sgf_game) -> Optional[float]:
 
 def is_selfplay_game(game: sgf.Sgf_game) -> bool:
     """Returns true if the game is a selfplay game for the adversary."""
-    colors: Sequence[Color] = (Color.BLACK, Color.WHITE)
+    colors = (Color.BLACK, Color.WHITE)
     player_names = [game.get_player_name(color.value.lower()) for color in colors]
     if player_names[0] != player_names[1]:
         return False

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -252,6 +252,7 @@ def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
             victim_visits=None,
             adv_visits=get_max_visits(game, Color.BLACK),
             game_hash=game_hash,
+            winner=None,
             score_diff=0,
             score_wo_komi_diff=0,
             is_selfplay=True,

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -249,7 +249,7 @@ def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
         return AdvGameInfo(
             board_size=game.get_size(),
             victim_name="",
-            victim_visits=None,
+            victim_visits=0,
             adv_visits=get_max_visits(game, Color.BLACK),
             game_hash=game_hash,
             winner=None,

--- a/python/curriculum.py
+++ b/python/curriculum.py
@@ -237,7 +237,7 @@ def is_selfplay_game(game: sgf.Sgf_game) -> bool:
 def get_game_info(sgf_str: str) -> Optional[AdvGameInfo]:
     try:
         game = sgf.Sgf_game.from_string(sgf_str)
-    except IndexError:
+    except ValueError:
         logging.warning("Error parsing game: '%s'", sgf_str, exc_info=True)
         return None
 

--- a/python/selfplay/shuffle_and_export_loop.sh
+++ b/python/selfplay/shuffle_and_export_loop.sh
@@ -49,7 +49,7 @@ cp "$GITROOTDIR"/python/*.py "$GITROOTDIR"/python/selfplay/*.sh "$DATED_ARCHIVE"
         ./shuffle.sh "$basedir" "$tmpdir" "$NTHREADS" "$BATCHSIZE" "$@"
         sleep 20
     done
-) >> "$basedir"/logs/outshuffle.txt 2>&1 & disown
+) >> "$basedir"/logs/outshuffle.txt 2>&1 &
 
 (
     cd "$basedir"/scripts
@@ -58,7 +58,7 @@ cp "$GITROOTDIR"/python/*.py "$GITROOTDIR"/python/selfplay/*.sh "$DATED_ARCHIVE"
         ./export_model_for_selfplay.sh "$NAMEPREFIX" "$basedir" "$USEGATING"
         sleep 10
     done
-) >> "$basedir"/logs/outexport.txt 2>&1 & disown
+) >> "$basedir"/logs/outexport.txt 2>&1 &
 
 exit 0
 }

--- a/python/selfplay/shuffle_and_export_loop.sh
+++ b/python/selfplay/shuffle_and_export_loop.sh
@@ -49,7 +49,7 @@ cp "$GITROOTDIR"/python/*.py "$GITROOTDIR"/python/selfplay/*.sh "$DATED_ARCHIVE"
         ./shuffle.sh "$basedir" "$tmpdir" "$NTHREADS" "$BATCHSIZE" "$@"
         sleep 20
     done
-) >> "$basedir"/logs/outshuffle.txt 2>&1 &
+) >> "$basedir"/logs/outshuffle.txt 2>&1 & disown
 
 (
     cd "$basedir"/scripts
@@ -58,7 +58,7 @@ cp "$GITROOTDIR"/python/*.py "$GITROOTDIR"/python/selfplay/*.sh "$DATED_ARCHIVE"
         ./export_model_for_selfplay.sh "$NAMEPREFIX" "$basedir" "$USEGATING"
         sleep 10
     done
-) >> "$basedir"/logs/outexport.txt 2>&1 &
+) >> "$basedir"/logs/outexport.txt 2>&1 & disown
 
 exit 0
 }


### PR DESCRIPTION
Setting up basic implementation of iterated adversarial training.
Associated `go_attack` PR: https://github.com/AlignmentResearch/go_attack/pull/106

Changes:
* `selfplay.cpp`: 
  * When performing victimplay, the config parameter `selfplayProportion` can be used to specify a proportion of games to be adversary-vs-adversary selfplay games instead of victimplay games. The purpose of this is to preserve the general competency of the adversary (e.g., if we're finetuning a KataGo model but still want it to be good at general Go play).
  * Fix victimplay workers crashing due to not finding `nnVictimPath` if they launch before curriculum creates the `nnVictimPath` directory. (With standard training is OK-ish because the victimplay workers just crash a few times at launch until the curriculum worker runs, but in iterated training the victimplay workers could potentially crash at every new iteration.)
* `curriculum.py`: Update to ignore selfplay games
* `evaluate_loop.sh`: Allow specifying different config for evaluation. (For iterated adversarial training, the config parameters should be different per iteration depending on whether we're training the cyclic-adversary against a KataGo network or training a KataGo network against the cyclic-adversary.)