### PR TITLE
gtp: Don't load victim model if using MCTS

### DIFF
--- a/cpp/command/gtp.cpp
+++ b/cpp/command/gtp.cpp
@@ -469,7 +469,17 @@ struct GTPEngine {
 
     nnEval = getNNEvaluator(nnModelFile, nnModelFile);
     if (opModelFile != "") {
-      opNNEval = getNNEvaluator(opModelFile, opModelFile);
+      if (params.usingAdversarialAlgo()) {
+        opNNEval = getNNEvaluator(opModelFile, opModelFile);
+      } else {
+        // Don't load opNNEval since it should be unused and it'd just take up
+        // GPU memory.
+        logger.write(
+            "Warning: Not using A-MCTS, so victim model ("
+            + opModelFile
+            + ") is ignored."
+        );
+      }
     }
 
     {


### PR DESCRIPTION
Issue:
* GTP has both the `-model` and `-victim-model` flag, with the `-victim-model` used to specify the victim for A-MCTS. If the user provides the `-victim-model` flag but is using MCTS, the victim model is still loaded despite being unused, taking up GPU memory.

Fix:
* Don't load the victim model if MCTS is used.

Alternatively, we could throw an error if the user sets the `-victim-model` flag when using MCTS. But this would make our launch script for transfer experiments more annoying, since the launch script always sets the `-victim-model` (it would either need to parse the KataGo config or be told by the user to determine whether MCTS/AMCTS is being used).