### PR TITLE
getAnalysisJson: Handle nullptr

### DIFF
--- a/cpp/search/searchresults.cpp
+++ b/cpp/search/searchresults.cpp
@@ -1869,6 +1869,9 @@ bool Search::getAnalysisJson(
     static constexpr int minMoves = 0;
 
     json moveInfos = json::array();
+    if(node == NULL) {
+      return moveInfos;
+    }
     Player pla = node->nextPla;
 
     vector<AnalysisData> buf;


### PR DESCRIPTION
Issue: When running  `./runoutputtests.sh`, `getAnalysisJson()` crashes on the test `Testing 1000 visits just before terminal position, then playing the pass and having tree reuse. allowDirectPolicyMoves false...` due to hitting a `nullptr`. (We stopped handling `nullptr` correctly when we refactored `getAnalysisJson()` to support `includeTree`.)

Fix: return empty JSON if `getAnalysisJson()` is called on a `nullptr` node