### PR TITLE
Make codespell ignore model.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
 
       - run:
           name: codespell
-          command: codespell -I .codespell.skip --skip='*.pyc,*.ipynb' ./python/
+          command: codespell -I .codespell.skip --skip='*.pyc,*.ipynb,python/model.py' ./python/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
 
       - run:
           name: codespell
-          command: codespell -I .codespell.skip --skip='*.pyc,*.ipynb,python/model.py' ./python/
+          command: codespell -I .codespell.skip --skip='*.pyc,*.ipynb,./python/model.py' ./python/
 
 workflows:
   version: 2


### PR DESCRIPTION
[Previously](https://app.circleci.com/jobs/github/AlignmentResearch/KataGo-custom/1469) was failing with the error:
```
./python/model.py:386: pythong ==> python
```
We fix this by ignoring `./python/model.py`

Not sure why why codespell started failing all of a sudden...