### PR TITLE
train.py: Add -disable-vtimeloss to PyTorch training

### DIFF
--- a/python/metrics_pytorch.py
+++ b/python/metrics_pytorch.py
@@ -413,6 +413,7 @@ class Metrics:
                     soft_policy_weight_scale=soft_policy_weight_scale,
                     value_loss_scale=value_loss_scale,
                     td_value_loss_scales=td_value_loss_scales,
+                    use_vtimeloss=use_vtimeloss,
                 )
                 for key,value in iresults.items():
                     if key != "loss_sum":
@@ -736,6 +737,7 @@ class Metrics:
         soft_policy_weight_scale,
         value_loss_scale,
         td_value_loss_scales,
+        use_vtimeloss,
     ):
         (
             policy_logits,
@@ -928,7 +930,7 @@ class Metrics:
             + loss_scorebelief_pdf
             + loss_scorestdev
             + loss_lead
-            + loss_variance_time
+            + (loss_variance_time if use_vtimeloss else 0)
         )
 
         results = {

--- a/python/metrics_pytorch.py
+++ b/python/metrics_pytorch.py
@@ -365,6 +365,7 @@ class Metrics:
         main_loss_scale,
         intermediate_loss_scale,
         intermediate_distill_scale,
+        use_vtimeloss,
     ):
         results = self.metrics_dict_batchwise_single_heads_output(
             raw_model,
@@ -375,6 +376,7 @@ class Metrics:
             value_loss_scale=value_loss_scale,
             td_value_loss_scales=td_value_loss_scales,
             is_intermediate=False,
+            use_vtimeloss=use_vtimeloss,
         )
         if main_loss_scale is not None:
             results["loss_sum"] = main_loss_scale * results["loss_sum"]
@@ -397,6 +399,7 @@ class Metrics:
                     value_loss_scale=value_loss_scale,
                     td_value_loss_scales=td_value_loss_scales,
                     is_intermediate=True,
+                    use_vtimeloss=use_vtimeloss,
                 )
                 for key,value in iresults.items():
                     if key != "loss_sum":
@@ -429,6 +432,7 @@ class Metrics:
         value_loss_scale,
         td_value_loss_scales,
         is_intermediate,
+        use_vtimeloss,
     ):
         (
             policy_logits,
@@ -649,7 +653,7 @@ class Metrics:
             + loss_scorebelief_pdf
             + loss_scorestdev
             + loss_lead
-            + loss_variance_time
+            + (loss_variance_time if use_vtimeloss else 0)
             + loss_shortterm_value_error
             + loss_shortterm_score_error
         )

--- a/python/test.py
+++ b/python/test.py
@@ -209,6 +209,7 @@ def main(args):
         main_loss_scale=1.0,
         intermediate_loss_scale=None,
         intermediate_distill_scale=None,
+        use_vtimeloss=True,
       )
       metrics = detensorify_metrics(metrics)
 

--- a/python/train.py
+++ b/python/train.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
   parser.add_argument('-intermediate-loss-scale', type=float, help='Loss factor scale for intermediate head', required=False)
   parser.add_argument('-intermediate-distill-scale', type=float, help='Distill factor scale for intermediate head', required=False)
 
-  parser.add_argument('-disable-vtimeloss', help='Disable vtimeloss for training', required=False, action='store_true')
+  parser.add_argument('-disable-vtimeloss', help='Disable vtimeloss for training', required=False, dest="use_vtimeloss", action='store_false')
 
   args = vars(parser.parse_args())
 
@@ -172,7 +172,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
   intermediate_loss_scale = args["intermediate_loss_scale"]
   intermediate_distill_scale = args["intermediate_distill_scale"]
 
-  disable_vtimeloss = args["disable_vtimeloss"]
+  use_vtimeloss = args["use_vtimeloss"]
 
   if lr_scale is None:
     lr_scale = 1.0
@@ -948,7 +948,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
           main_loss_scale=main_loss_scale,
           intermediate_loss_scale=intermediate_loss_scale,
           intermediate_distill_scale=intermediate_distill_scale,
-          use_vtimeloss=not disable_vtimeloss,
+          use_vtimeloss=use_vtimeloss,
         )
 
         # DDP averages loss across instances, so to preserve LR as per-sample lr, we scale by world size.
@@ -1155,7 +1155,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
               main_loss_scale=main_loss_scale,
               intermediate_loss_scale=intermediate_loss_scale,
               intermediate_distill_scale=intermediate_distill_scale,
-              use_vtimeloss=not disable_vtimeloss,
+              use_vtimeloss=use_vtimeloss,
             )
             metrics = detensorify_metrics(metrics)
             accumulate_metrics(val_metric_sums, val_metric_weights, metrics, batch_size, decay=1.0, new_weight=1.0)

--- a/python/train.py
+++ b/python/train.py
@@ -91,6 +91,8 @@ if __name__ == "__main__":
   parser.add_argument('-intermediate-loss-scale', type=float, help='Loss factor scale for intermediate head', required=False)
   parser.add_argument('-intermediate-distill-scale', type=float, help='Distill factor scale for intermediate head', required=False)
 
+  parser.add_argument('-disable-vtimeloss', help='Disable vtimeloss for training', required=False, action='store_true')
+
   args = vars(parser.parse_args())
 
 
@@ -169,6 +171,8 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
   main_loss_scale = args["main_loss_scale"]
   intermediate_loss_scale = args["intermediate_loss_scale"]
   intermediate_distill_scale = args["intermediate_distill_scale"]
+
+  disable_vtimeloss = args["disable_vtimeloss"]
 
   if lr_scale is None:
     lr_scale = 1.0
@@ -944,6 +948,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
           main_loss_scale=main_loss_scale,
           intermediate_loss_scale=intermediate_loss_scale,
           intermediate_distill_scale=intermediate_distill_scale,
+          use_vtimeloss=not disable_vtimeloss,
         )
 
         # DDP averages loss across instances, so to preserve LR as per-sample lr, we scale by world size.
@@ -1150,6 +1155,7 @@ def main(rank: int, world_size: int, args, multi_gpu_device_ids, readpipes, writ
               main_loss_scale=main_loss_scale,
               intermediate_loss_scale=intermediate_loss_scale,
               intermediate_distill_scale=intermediate_distill_scale,
+              use_vtimeloss=not disable_vtimeloss,
             )
             metrics = detensorify_metrics(metrics)
             accumulate_metrics(val_metric_sums, val_metric_weights, metrics, batch_size, decay=1.0, new_weight=1.0)


### PR DESCRIPTION
With the old TF training code we had a flag `-disable-vtimeloss` to disable the variance time loss. We removed it when we moved to KataGo v1.12.0, which changes the training code to PyTorch, since we didn't want to add extraneous changes to the PyTorch code and we weren't using the PyTorch code.

This PR adds the `-disable-vtimeloss` flag back.

Testing: Checked that running `train.py` with `-disable-vtimeloss` drives the loss down without driving vtimeloss down.