### PR TITLE
Search: Fix segfault by initializing oppBot for A-MCTS

### DIFF
--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -117,8 +117,6 @@ Search::Search(
     // When using AMCTS, we don't support graph search for ourselves or our
     // opponent.
     assert(!searchParams.useGraphSearch);
-    // We only want to initialize oppBot if maxVisits > 1 or else we'll get
-    // infinite recursion when both bots are using A-MCTS.
     if (searchParams.maxVisits > 1) {
       assert(oppNNEval != nullptr);
       oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
@@ -179,15 +177,9 @@ string Search::getRankStr() const {
            std::to_string(bot->searchParams.rootNumSymmetriesToSample);
   };
 
-  if (searchParams.usingAdversarialAlgo()) {
-    string rankStr = "algo=" + searchParams.getSearchAlgoAsStr() + "," + getVisitStr(this, "");
-    // oppBot may be null if the number of visits is 1.
-    if (oppBot != nullptr) {
-      rankStr += "," + getVisitStr(oppBot.get(), "opp_");
-    }
-    return rankStr;
-  }
-  
+  if (searchParams.usingAdversarialAlgo())
+    return "algo=" + searchParams.getSearchAlgoAsStr() + "," + getVisitStr(this, "") + "," + getVisitStr(oppBot.get(), "opp_");
+
   if (searchParams.searchAlgo == SearchParams::SearchAlgorithm::MCTS)
     return "algo=MCTS," + getVisitStr(this, "");
 

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -122,11 +122,11 @@ Search::Search(
       // needs to create oppBot representing bot 1, but oppBot->oppBot doesn't
       // need to exist since oppBot will have maxVisits==1 and hence will never
       // evaluate oppBot->oppBot.
-      // Even if bot 0 itself only has maxVisits==1, though, it still should
-      // create oppBot in case the number of visits changes later. E.g.,
-      // during victimplay, at the end of a game, bots are used with a modified
-      // number of visits to estimate stats of the board.
-      //
+      // (We should initialize oppBot based on whether oppNNEval is nullptr
+      // rather than whther maxVisits is 1. Even if bot 0 has maxVisits==1, it
+      // still should create oppBot in case the number of visits changes later.
+      // E.g., during victimplay, at the end of a game, bots are used with a
+      // modified number of visits to estimate stats of the board.)
     } else {
       oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
         ? params.oppVisitsOverride.value_or(oppParams.maxVisits)

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -180,7 +180,10 @@ Search::~Search() {
 }
 
 string Search::getRankStr() const {
-  const auto getVisitStr = [](const Search* bot, string prefix) {
+  const auto getVisitStr = [](const Search* bot, string prefix) -> string {
+    if (bot == nullptr) {
+      return "NULL";
+    }
     return prefix + "v=" + std::to_string(bot->searchParams.maxVisits) + "," +
            prefix + "rsym=" +
            std::to_string(bot->searchParams.rootNumSymmetriesToSample);

--- a/cpp/search/search.cpp
+++ b/cpp/search/search.cpp
@@ -137,19 +137,6 @@ Search::Search(
       oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
       oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
     }
-
-
-    if (searchParams.maxVisits > 1) {
-      assert(oppNNEval != nullptr);
-      oppParams.maxVisits = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_R
-        ? params.oppVisitsOverride.value_or(oppParams.maxVisits)
-        : 1;
-      // We don't want to recursively model an opponent also using A-MCTS or else
-      // we'll have infinite recursion.
-      assert(!oppParams.usingAdversarialAlgo() || oppParams.maxVisits == 1);
-      oppParams.rootNumSymmetriesToSample = params.searchAlgo == SearchParams::SearchAlgorithm::AMCTS_S ? 1 : oppParams.rootNumSymmetriesToSample;
-      oppBot = make_unique<Search>(oppParams, oppNNEval, logger, rSeed + "-victim-model");
-    }
   }
 
   assert(logger != NULL);


### PR DESCRIPTION
### Bug 
Say I'm running `victimplay` with one of the bots running A-MCTS with one visit. Typically in A-MCTS, the bot will initialize `oppBot` to model the opponent bot. However, we don't initialize `oppBot` with the number of visits is 1 because then the oppBot will never be evaluated during the course of the game. This check on the number of visits prevents two A-MCTS bots from modeling each other in an infinite loop (i.e., A-MCTS bot 0 initializes oppBot with 1 visit to model A-MCTS bot 1, and then oppBot->oppBot is not initialized due to the check on visits == 1).

But `victimplay` actually runs the bots with a different number of visits at the end of the game in order to, e.g., compute the lead. Then `oppBot` being uninitialized causes a segfault.

### Fix

Initialize `oppBot` based on whether the argument `oppNNEval` is provided rather than based on the number of visits. Then a 1-visit A-MCTS bot will initialize oppBot, but oppBot->oppBot is still not initialized as desired.

### Testing

Run victimplay with both bots using 1 visit and AMCTS , check it doesn't crash:
`./katago victimplay -config /go_attack/configs/active-experiment.cfg -config /go_attack/configs/compute/1gpu.cfg   -config /go_attack/configs/extra.cfg -models-dir /nas/ucb/k8/go-attack/victimplay/ttseng-gating-on-20221229-151219/models -nn-victim-path /nas/ucb/k8/go-attack/victimplay/ttseng-gating-on-20221229-151219/victims  -max-games-total 4 -output-dir /tmp/asdf`
with `extra.cfg` being:
```
bSizes=5
bSizeRelProbs=1
komiByBSize=6.5
logSearchInfo=true
logToStdout=true
maxVisits0=1
maxVisits1=1
searchAlgorithm1=AMCTS
useGraphSearch=false
```