### PR TITLE
TF export model: Don't use any GPU memory

### DIFF
--- a/python/export_model.py
+++ b/python/export_model.py
@@ -73,8 +73,7 @@ saver = tf.compat.v1.train.Saver(
 )
 
 #Some tensorflow options
-#tfconfig = tf.compat.v1.ConfigProto(log_device_placement=False,device_count={'GPU': 0})
-tfconfig = tf.compat.v1.ConfigProto(log_device_placement=False)
+tfconfig = tf.compat.v1.ConfigProto(log_device_placement=False,device_count={'GPU': 0})
 #tfconfig.gpu_options.allow_growth = True
 #tfconfig.gpu_options.per_process_gpu_memory_fraction = 0.4
 with tf.compat.v1.Session(config=tfconfig) as session:


### PR DESCRIPTION
__Context__: By default, `with tf.compat.v1.Session() as session:` claims a few hundred megabytes of GPU memory on every GPU. As a result, despite `export_model.py` not using GPUs, it can crash if some GPU has no GPU memory remaining. This, combined with [0-GPU Kubernetes jobs actually having all GPUs visible](https://farinc.slack.com/archives/C054KEQ0PPE/p1705737731678899), has caused the exporter to unexpectedly crash in recent training runs.

__Changes__: Set TF config to not use GPUs.

__Testing__: Exported a model (`python3 ./export_model.py -saved-model-dir <nonexported_model>/saved_model/ -export-dir /tmp/ -model-name foo -name-scope "swa_model" -filename-prefix model -for-cuda`) with this PR and without this PR, checked the `sha256sum` of the resulting exported models were the same.