### PR TITLE
Add flag for scaling move limit with board size

### DIFF
--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -2322,26 +2322,34 @@ void Play::maybeHintForkGame(
 
 
 GameRunner::GameRunner(ConfigParser& cfg, PlaySettings pSettings, Logger& logger)
-  :logSearchInfo(),logMoves(),maxMovesPerGame(),clearBotBeforeSearch(),
+  :logSearchInfo(),logMoves(),maxMovesPerGame(),scaleMaxMovesWithBoardSize(),clearBotBeforeSearch(),
    playSettings(pSettings),
    gameInit(NULL)
 {
   logSearchInfo = cfg.getBool("logSearchInfo");
   logMoves = cfg.getBool("logMoves");
   maxMovesPerGame = cfg.getInt("maxMovesPerGame",0,1 << 30);
+  scaleMaxMovesWithBoardSize =
+    cfg.contains("scaleMaxMovesWithBoardSize")
+    ? cfg.getBool("scaleMaxMovesWithBoardSize")
+    : false;
   clearBotBeforeSearch = cfg.contains("clearBotBeforeSearch") ? cfg.getBool("clearBotBeforeSearch") : false;
 
   //Initialize object for randomizing game settings
   gameInit = new GameInitializer(cfg,logger);
 }
 GameRunner::GameRunner(ConfigParser& cfg, const string& gameInitRandSeed, PlaySettings pSettings, Logger& logger)
-  :logSearchInfo(),logMoves(),maxMovesPerGame(),clearBotBeforeSearch(),
+  :logSearchInfo(),logMoves(),maxMovesPerGame(),scaleMaxMovesWithBoardSize(),clearBotBeforeSearch(),
    playSettings(pSettings),
    gameInit(NULL)
 {
   logSearchInfo = cfg.getBool("logSearchInfo");
   logMoves = cfg.getBool("logMoves");
   maxMovesPerGame = cfg.getInt("maxMovesPerGame",0,1 << 30);
+  scaleMaxMovesWithBoardSize =
+    cfg.contains("scaleMaxMovesWithBoardSize")
+    ? cfg.getBool("scaleMaxMovesWithBoardSize")
+    : false;
   clearBotBeforeSearch = cfg.contains("clearBotBeforeSearch") ? cfg.getBool("clearBotBeforeSearch") : false;
 
   //Initialize object for randomizing game settings
@@ -2495,13 +2503,18 @@ FinishedGameData* GameRunner::runGame(
     }
   }
 
+  const int gameMaxMoves =
+    scaleMaxMovesWithBoardSize
+    ? maxMovesPerGame * board.x_size * board.y_size / (19 * 19)
+    : maxMovesPerGame;
+
   FinishedGameData* finishedGameData = Play::runGame(
     board,pla,hist,extraBlackAndKomi,
     botSpecB,botSpecW,
     botB,botW,
     doEndGameIfAllPassAlive,clearBotBeforeSearchThisGame,
     logger,logSearchInfo,logMoves,
-    maxMovesPerGame,shouldStop,
+    gameMaxMoves,shouldStop,
     shouldPause,
     playSettings,otherGameProps,
     gameRand,

--- a/cpp/program/play.h
+++ b/cpp/program/play.h
@@ -315,6 +315,8 @@ class GameRunner {
   bool logSearchInfo;
   bool logMoves;
   int maxMovesPerGame;
+  // If true, max moves is adjusted to maxMovesPerGame * <board area> / 19^2.
+  bool scaleMaxMovesWithBoardSize;
   bool clearBotBeforeSearch;
   PlaySettings playSettings;
   GameInitializer* gameInit;


### PR DESCRIPTION
In our training run attacking b18, I saw that some small-board games were very long, e.g., an 11x11 game hit the move limit of 1600. 1600 moves is already a very generous move limit for 19x19 games. Probably we're hitting the move limit 
due to pass-alive hardening.

Let's reduce the move limit for small-board games — this PR adds a boolean config parameter `scaleMaxMovesWithBoardSize`. If enabled, the move limit is scaled by `(board area) / 19^2`.