### PR TITLE
pytorchbackend: Fix ViT multi-gpu support

### DIFF
--- a/cpp/neuralnet/pytorchbackend.cpp
+++ b/cpp/neuralnet/pytorchbackend.cpp
@@ -42,8 +42,12 @@ LoadedModel::LoadedModel(const std::string& filename)
   , modelName(filename) {}
 
 LoadedModel::LoadedModel(const LoadedModel& other)
-  : model(other.model.clone())
-  , modelName(other.modelName) {}
+  : modelName(other.modelName) {
+  {
+    const std::lock_guard<std::mutex> guard(other.cloneMutex);
+    model = other.model.clone();
+  }
+}
 
 LoadedModel* loadModelFile(const std::string& file, const std::string& expectedSha256) {
   if (expectedSha256.size() != 0) {

--- a/cpp/neuralnet/pytorchbackend.h
+++ b/cpp/neuralnet/pytorchbackend.h
@@ -2,6 +2,7 @@
 #ifndef NEURALNET_PYTORCHBACKEND_H_
 #define NEURALNET_PYTORCHBACKEND_H_
 
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -67,6 +68,12 @@ namespace TorchNeuralNet {
 struct LoadedModel {
   torch::jit::script::Module model;
   std::string modelName;
+  // If numNNServerThreads > 1, then multiple threads concurrently invoke
+  // LoadedModel's copy constructor. But cloning a torch::jit::script::Module
+  // appears to not be thread-safe, giving errors like "method
+  // '__torch__.torch.nn.modules.linear.___torch_mangle_5.Linear.forward'
+  // already defined."
+  mutable std::mutex cloneMutex;
 
   LoadedModel(const std::string& filename);
   LoadedModel(const LoadedModel& other);


### PR DESCRIPTION
When running the C++ TorchScript back-end with multiple server threads per model, which happens when we are using multiple GPUs, we get JiT errors like
```
terminate called after throwing an instance of 'c10::Error'
  what():  method '__torch__.torch.nn.modules.linear.___torch_mangle_14.Linear.forward' already defined.
Exception raised from register_function at ../torch/csrc/jit/api/compilation_unit.h:309 (most recent call first):
```
This happens when threads concurrently try to copy a model.

This PR fixes this issue by putting a mutex around model copying.