### PR TITLE
cpp: Add flags for penalizing hit-move-limit games

### DIFF
--- a/cpp/neuralnet/nneval.cpp
+++ b/cpp/neuralnet/nneval.cpp
@@ -951,7 +951,10 @@ void NNEvaluator::evaluate(
         double shorttermWinlossErrorPreSoftplus = buf.result->shorttermWinlossError;
         double shorttermScoreErrorPreSoftplus = buf.result->shorttermScoreError;
 
-        if(history.rules.koRule != Rules::KO_SIMPLE && history.rules.scoringRule != Rules::SCORING_TERRITORY)
+        const bool shouldClearNoResult = history.rules.koRule != Rules::KO_SIMPLE
+          && history.rules.scoringRule != Rules::SCORING_TERRITORY
+          && !nnInputParams.forceAllowNoResultPredictions;
+        if(shouldClearNoResult)
           noResultLogits -= 100000.0;
 
         //Softmax
@@ -960,7 +963,7 @@ void NNEvaluator::evaluate(
         lossProb = exp(lossLogits - maxLogits);
         noResultProb = exp(noResultLogits - maxLogits);
 
-        if(history.rules.koRule != Rules::KO_SIMPLE && history.rules.scoringRule != Rules::SCORING_TERRITORY)
+        if(shouldClearNoResult)
           noResultProb = 0.0;
 
         double probSum = winProb + lossProb + noResultProb;

--- a/cpp/neuralnet/nninputs.cpp
+++ b/cpp/neuralnet/nninputs.cpp
@@ -51,6 +51,8 @@ const Hash128 MiscNNInputParams::ZOBRIST_AVOID_MYTDAGGER_HACK =
   Hash128(0x612d22ec402ce054ULL, 0x0db915c49de527aeULL);
 const Hash128 MiscNNInputParams::ZOBRIST_POLICY_OPTIMISM =
   Hash128(0x88415c85c2801955ULL, 0x39bdf76b2aaa5eb1ULL);
+const Hash128 MiscNNInputParams::ZOBRIST_FORCE_ALLOW_NO_RESULT_PREDICTIONS =
+  Hash128(0x6b1bb6886e68e68aULL, 0xc647feb1fb8ceca2ULL);
 
 //-----------------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------
@@ -945,6 +947,9 @@ Hash128 NNInputs::getHash(
     hash.hash0 = Hash::rrmxmx(Hash::splitMix64(hash.hash0) + (uint64_t)policyOptimismDiscretized);
     hash.hash1 = Hash::rrmxmx(hash.hash1 + hash.hash0 + (uint64_t)policyOptimismDiscretized);
   }
+
+  if(nnInputParams.forceAllowNoResultPredictions)
+    hash ^= MiscNNInputParams::ZOBRIST_FORCE_ALLOW_NO_RESULT_PREDICTIONS;
 
   return hash;
 }

--- a/cpp/neuralnet/nninputs.h
+++ b/cpp/neuralnet/nninputs.h
@@ -52,6 +52,7 @@ struct MiscNNInputParams {
   static const Hash128 ZOBRIST_NN_POLICY_TEMP;
   static const Hash128 ZOBRIST_AVOID_MYTDAGGER_HACK;
   static const Hash128 ZOBRIST_POLICY_OPTIMISM;
+  static const Hash128 ZOBRIST_FORCE_ALLOW_NO_RESULT_PREDICTIONS;
 };
 
 namespace NNInputs {

--- a/cpp/neuralnet/nninputs.h
+++ b/cpp/neuralnet/nninputs.h
@@ -43,6 +43,7 @@ struct MiscNNInputParams {
   // If no symmetry is specified, it will use default or random based on config, unless node is already cached.
   int symmetry = NNInputs::SYMMETRY_NOTSPECIFIED;
   double policyOptimism = 0.0;
+  bool forceAllowNoResultPredictions = false;
 
   static const Hash128 ZOBRIST_CONSERVATIVE_PASS;
   static const Hash128 ZOBRIST_FRIENDLY_PASS;

--- a/cpp/program/play.cpp
+++ b/cpp/program/play.cpp
@@ -1645,7 +1645,7 @@ FinishedGameData* Play::runGame(
     gameData->finalOwnership = new Color[Board::MAX_ARR_SIZE];
     gameData->finalSekiAreas = new bool[Board::MAX_ARR_SIZE];
 
-    if(hist.isGameFinished && hist.isNoResult) {
+    if((hist.isGameFinished && hist.isNoResult) || (playSettings.hitTurnLimitIsNoResult && gameData->hitTurnLimit)) {
       finalValueTargets.win = 0.0f;
       finalValueTargets.loss = 0.0f;
       finalValueTargets.noResult = 1.0f;

--- a/cpp/program/playsettings.cpp
+++ b/cpp/program/playsettings.cpp
@@ -16,7 +16,8 @@ PlaySettings::PlaySettings()
    allowResignation(false),resignThreshold(0.0),resignConsecTurns(1),
    forSelfPlay(false),
    handicapAsymmetricPlayoutProb(0.0),normalAsymmetricPlayoutProb(0.0),maxAsymmetricRatio(2.0),
-   recordTimePerMove(false)
+   recordTimePerMove(false),
+   hitTurnLimitIsNoResult(false)
 {}
 PlaySettings::~PlaySettings()
 {}
@@ -94,6 +95,7 @@ PlaySettings PlaySettings::loadForSelfplay(ConfigParser& cfg, bool isDistributed
   playSettings.minAsymmetricCompensateKomiProb = cfg.getDouble("minAsymmetricCompensateKomiProb",0.0,1.0);
   playSettings.sekiForkHackProb = cfg.contains("sekiForkHackProb") ? cfg.getDouble("sekiForkHackProb",0.0,1.0) : 0.0;
   playSettings.forSelfPlay = true;
+  playSettings.hitTurnLimitIsNoResult = cfg.contains("hitTurnLimitIsNoResult") ? cfg.getBool("hitTurnLimitIsNoResult") : false;
 
   if(playSettings.policySurpriseDataWeight + playSettings.valueSurpriseDataWeight > 1.0)
     throw StringError("policySurpriseDataWeight + valueSurpriseDataWeight > 1.0");

--- a/cpp/program/playsettings.h
+++ b/cpp/program/playsettings.h
@@ -83,6 +83,12 @@ struct PlaySettings {
   //Record time taken per move
   bool recordTimePerMove;
 
+  // Consider hitting the turn limit to be a no-result game when populating
+  // value targets for NN training. (In particular, this does not make MCTS
+  // mark hit-turn-limit games as terminal nodes with no result. MCTS does not know
+  // the turn limit and therefore cannot mark hit-turn-limit games as terminal.)
+  bool hitTurnLimitIsNoResult;
+
   PlaySettings();
   ~PlaySettings();
 

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -458,8 +458,8 @@ void Setup::loadParams(
     if(cfg.contains("noResultUtilityForWhite"+idxStr)) params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite"+idxStr, -1.0, 1.0);
     else if(cfg.contains("noResultUtilityForWhite"))   params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite",        -1.0, 1.0);
     else if(applyDefaultParams)                        params.noResultUtilityForWhite = 0.0;
-    if(cfg.contains("noResultUtility"+idxStr)) params.noResultUtility = cfg.getDouble("noResultUtility"+idxStr, -1.0, 1.0);
-    else if(cfg.contains("noResultUtility"))   params.noResultUtility = cfg.getDouble("noResultUtility",        -1.0, 1.0);
+    if(cfg.contains("noResultUtility"+idxStr)) params.noResultUtility = cfg.getDouble("noResultUtility"+idxStr, -4.0, 4.0);
+    else if(cfg.contains("noResultUtility"))   params.noResultUtility = cfg.getDouble("noResultUtility",        -4.0, 4.0);
     else if(applyDefaultParams)                params.noResultUtility = 0.0;
     if(cfg.contains("drawEquivalentWinsForWhite"+idxStr)) params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite"+idxStr, 0.0, 1.0);
     else if(cfg.contains("drawEquivalentWinsForWhite"))   params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite",        0.0, 1.0);

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -458,6 +458,9 @@ void Setup::loadParams(
     if(cfg.contains("noResultUtilityForWhite"+idxStr)) params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite"+idxStr, -1.0, 1.0);
     else if(cfg.contains("noResultUtilityForWhite"))   params.noResultUtilityForWhite = cfg.getDouble("noResultUtilityForWhite",        -1.0, 1.0);
     else if(applyDefaultParams)                        params.noResultUtilityForWhite = 0.0;
+    if(cfg.contains("noResultUtility"+idxStr)) params.noResultUtility = cfg.getDouble("noResultUtility"+idxStr, -1.0, 1.0);
+    else if(cfg.contains("noResultUtility"))   params.noResultUtility = cfg.getDouble("noResultUtility",        -1.0, 1.0);
+    else if(applyDefaultParams)                params.noResultUtility = 0.0;
     if(cfg.contains("drawEquivalentWinsForWhite"+idxStr)) params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite"+idxStr, 0.0, 1.0);
     else if(cfg.contains("drawEquivalentWinsForWhite"))   params.drawEquivalentWinsForWhite = cfg.getDouble("drawEquivalentWinsForWhite",        0.0, 1.0);
     else if(applyDefaultParams)                           params.drawEquivalentWinsForWhite = 0.5;

--- a/cpp/program/setup.cpp
+++ b/cpp/program/setup.cpp
@@ -492,6 +492,9 @@ void Setup::loadParams(
     else if(cfg.contains("cpuctUtilityStdevScale"))   params.cpuctUtilityStdevScale = cfg.getDouble("cpuctUtilityStdevScale",        0.0, 1.0);
     else if(applyDefaultParams)                       params.cpuctUtilityStdevScale = ((setupFor != SETUP_FOR_DISTRIBUTED && setupFor != SETUP_FOR_OTHER) ? 0.85 : 0.0);
 
+    if(cfg.contains("forceAllowNoResultPredictions"+idxStr)) params.forceAllowNoResultPredictions = cfg.getBool("forceAllowNoResultPredictions"+idxStr);
+    else if(cfg.contains("forceAllowNoResultPredictions"))   params.forceAllowNoResultPredictions = cfg.getBool("forceAllowNoResultPredictions");
+    else if(applyDefaultParams)                             params.forceAllowNoResultPredictions = false;
 
     if(cfg.contains("fpuReductionMax"+idxStr)) params.fpuReductionMax = cfg.getDouble("fpuReductionMax"+idxStr, 0.0, 2.0);
     else if(cfg.contains("fpuReductionMax"))   params.fpuReductionMax = cfg.getDouble("fpuReductionMax",        0.0, 2.0);

--- a/cpp/search/searchhelpers.cpp
+++ b/cpp/search/searchhelpers.cpp
@@ -222,14 +222,16 @@ std::shared_ptr<NNOutput>* Search::maybeAddPolicyNoiseAndTemp(SearchThread& thre
 double Search::getResultUtility(double winLossValue, double noResultValue) const {
   return (
     winLossValue * searchParams.winLossUtilityFactor +
-    noResultValue * searchParams.noResultUtilityForWhite
+    noResultValue * searchParams.noResultUtilityForWhite +
+    noResultValue * searchParams.noResultUtility * (rootPla == P_WHITE ? 1 : -1)
   );
 }
 
 double Search::getResultUtilityFromNN(const NNOutput& nnOutput) const {
   return (
     (nnOutput.whiteWinProb - nnOutput.whiteLossProb) * searchParams.winLossUtilityFactor +
-    nnOutput.whiteNoResultProb * searchParams.noResultUtilityForWhite
+    nnOutput.whiteNoResultProb * searchParams.noResultUtilityForWhite +
+    nnOutput.whiteNoResultProb * searchParams.noResultUtility * (rootPla == P_WHITE ? 1 : -1)
   );
 }
 

--- a/cpp/search/searchnnhelpers.cpp
+++ b/cpp/search/searchnnhelpers.cpp
@@ -19,6 +19,7 @@ void Search::computeRootNNEvaluation(NNResultBuf& nnResultBuf, bool includeOwner
   nnInputParams.nnPolicyTemperature = searchParams.nnPolicyTemperature;
   nnInputParams.avoidMYTDaggerHack = searchParams.avoidMYTDaggerHackPla == pla;
   nnInputParams.policyOptimism = searchParams.rootPolicyOptimism;
+  nnInputParams.forceAllowNoResultPredictions = searchParams.forceAllowNoResultPredictions;
   if(searchParams.playoutDoublingAdvantage != 0) {
     Player playoutDoublingAdvantagePla = getPlayoutDoublingAdvantagePla();
     nnInputParams.playoutDoublingAdvantage = (
@@ -56,6 +57,7 @@ bool Search::initNodeNNOutput(
   nnInputParams.nnPolicyTemperature = searchParams.nnPolicyTemperature;
   nnInputParams.avoidMYTDaggerHack = searchParams.avoidMYTDaggerHackPla == thread.pla;
   nnInputParams.policyOptimism = isRoot ? searchParams.rootPolicyOptimism : searchParams.policyOptimism;
+  nnInputParams.forceAllowNoResultPredictions = searchParams.forceAllowNoResultPredictions;
   if(searchParams.playoutDoublingAdvantage != 0) {
     Player playoutDoublingAdvantagePla = getPlayoutDoublingAdvantagePla();
     nnInputParams.playoutDoublingAdvantage = (

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -59,6 +59,7 @@ struct SearchParams {
   double dynamicScoreCenterZeroWeight; //Adjust dynamic score center this proportion of the way towards zero, capped at a reasonable amount.
   double dynamicScoreCenterScale; //Adjust dynamic score scale. 1.0 indicates that score is cared about roughly up to board sizeish.
   double noResultUtilityForWhite; //Utility of having a no-result game (simple ko rules or nonterminating territory encore)
+  double noResultUtility; //Utility of having a no-result game, regardless of player's color.
   double drawEquivalentWinsForWhite; //Consider a draw to be this many wins and one minus this many losses.
 
   //Search tree exploration parameters

--- a/cpp/search/searchparams.h
+++ b/cpp/search/searchparams.h
@@ -62,6 +62,12 @@ struct SearchParams {
   double noResultUtility; //Utility of having a no-result game, regardless of player's color.
   double drawEquivalentWinsForWhite; //Consider a draw to be this many wins and one minus this many losses.
 
+  // Typically no-result is only allowed under certain rule sets, and the
+  // no-result logit is cleared out under incompatible rule sets.
+  // If "hitTurnLimitIsNoResult" is enabled then this may no longer be true.
+  // Setting this param means that no-result logits are no longer cleared.
+  bool forceAllowNoResultPredictions;
+
   //Search tree exploration parameters
   double cpuctExploration;  //Constant factor on exploration, should also scale up linearly with magnitude of utility
   double cpuctExplorationLog; //Constant factor on log-scaling exploration, should also scale up linearly with magnitude of utility


### PR DESCRIPTION
For our gift-adversary, we needed these flags to penalize games that hit the move limit.

Added config flags:
* bot setting `noResultUtility`: Sets utility of no-result games. (The `noResultUtilityForWhite` flag already exists, which makes sense for self-play where the same trained bot is playing both colors and the utility should be zero-sum to keep training consistent. It doesn't fit the situation where we want to set the utility of no-result games for the adversary in victimplay regardless of the adversary's color.)
* game setting `hitTurnLimitIsNoResult`: Mark hit-turn limit games as no-result in training, as opposed to scoring and marking win/loss based on the 
* bot setting `forceAllowNoResultPredictions`: Force no-result logits to be not zeroed. No-result games are supposed to only occur in certain rule sets, and no-result value logits are cleared out in other rule sets. This is no longer true now that `hitTurnLimitIsNoResult` exists. (I thought about not having this flag and just not clearing logits if `hitTurnLimitIsNoResult` is true, but actually we want to be able to set this on a per-bot basis — we still want the victim to be clearing its logits even if the adv is not)