### PR TITLE
selfplay: Make `useAuxPolicyTarget` parameter optional

### DIFF
--- a/cpp/command/selfplay.cpp
+++ b/cpp/command/selfplay.cpp
@@ -375,7 +375,7 @@ int MainCmds::selfplay(const vector<string>& args, const bool victimplay) {
 
     tdataWriter->forVictimplay = victimplay;
     tdataWriter->allowSelfplayInVictimplay = selfplayProportion > 0.0;
-    tdataWriter->useAuxPolicyTarget = cfg.getBool("useAuxPolicyTarget");
+    tdataWriter->useAuxPolicyTarget = cfg.contains("useAuxPolicyTarget") ? cfg.getBool("useAuxPolicyTarget") : true;
 
     ofstream* sgfOut = NULL;
     if(sgfOutputDir.length() > 0) {


### PR DESCRIPTION
We added a config flag `useAuxPolicyTarget` in https://github.com/AlignmentResearch/KataGo-custom/pull/8/commits/f2ee97a99eb80d304c81bbd8b230c2b5965be376. Currently we throw an error if the param is not specified

This PR makes it so that this param is optional, so that selfplay runs can directly use configs from `engines/KataGo-raw/cpp/configs`.