### PR TITLE
TF export model: Don't use any GPU memory (attempt 2)

### DIFF
--- a/python/export_model.py
+++ b/python/export_model.py
@@ -9,6 +9,9 @@ import json
 import datetime
 import struct
 
+# Stop TF from claiming any GPU memory:
+# https://datascience.stackexchange.com/a/58846
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 import tensorflow as tf
 import numpy as np
 


### PR DESCRIPTION
In PR #104 I noticed that `export_model.py` can claim some GPU memory, causing the exporter to crash if the GPU has no more memory left. I tried to fix this in the PR but apparently I was wrong (my fix only reduced GPU memory usage).

This PR fixes the issue by setting `CUDA_VISIBLE_DEVICES`.

Base branch is `tensorflow`, after this merges I need to update `KataGo-tensorflow` (not `KataGo-custom`) to the head of `tensorflow`.

Testing: add `time.sleep(100000)` after the Tensorflow session is initialized, check that before this PR that there is GPU memory claimed and that after this PR there is no GPU memory claimed