### PR TITLE
pytorchbackend: Note how to run GTP on small board sizes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,7 @@ executors:
     environment:
       NUM_CPUS: 8
   cpp-gpu:
-    machine: true
-    resource_class: alignmentresearch/go-attack-linux-gpu
+    resource_class: alignmentresearch/far-gpu-4cpu-16g
   python:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,9 @@ executors:
     environment:
       NUM_CPUS: 8
   cpp-gpu:
+    <<: *defaults
+    docker:
+      - image: humancompatibleai/goattack:cpp-build-deps
     resource_class: alignmentresearch/far-gpu-4cpu-16g
   python:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     <<: *defaults
     docker:
       - image: humancompatibleai/goattack:cpp-build-deps
-    resource_class: alignmentresearch/far-gpu-4cpu-16g
+    resource_class: alignmentresearch/far-gpu-14cpu-60g
   python:
     <<: *defaults
     docker:

--- a/cpp/neuralnet/pytorchbackend.cpp
+++ b/cpp/neuralnet/pytorchbackend.cpp
@@ -252,9 +252,10 @@ void getOutput(
     //
     // The other backends handle this but I (tomtseng) haven't investigated how.
     // For now we'll just enforce that nnXLen and nnYLen are 19. If a user wants
-    // to play on a 5x5 board, they should include 19 in the bSizes config
-    // parameter (and set its bSizeRelProbs to 0 if they don't actually want any
-    // 19x19 games), otherwise we throw an exception here.
+    // to run `match` or training on smaller boards, they should still include
+    // 19 in the bSizes config parameter (and set its bSizeRelProbs to 0 if they
+    // don't actually want any 19x19 games). For GTP the user should set
+    // gtpForceMaxNNSize to true. Otherwise they'll see this exception.
     throw StringError(Global::strprintf("Board len not yet supported: %d x %d", nnXLen, nnYLen));
   }
   constexpr bool INPUTS_USE_NHWC = false;


### PR DESCRIPTION
If I `loadsgf` a 11x11 game in GTP mode with the Pytorch backend I get the error "Board len not yet supported", but it turns out there's an existing config parameter `gtpForceMaxNNSize` that can avoid this error. This PR notes in the code comment above the error that the user should set this config param.

Also modify .circleci to make GPU tests work again.